### PR TITLE
basis_sets_O1: Compatible with basis_sets_base.py

### DIFF
--- a/src/symfc/basis_sets/basis_sets_O1.py
+++ b/src/symfc/basis_sets/basis_sets_O1.py
@@ -112,6 +112,16 @@ class FCBasisSetO1(FCBasisSetO1Base):
         """
         return self._full_basis_set
 
+    @property
+    def compact_compression_matrix(self) -> Optional[np.ndarray]:
+        """Return compression matrix for compact basis set."""
+        pass
+
+    @property
+    def compression_matrix(self) -> Optional[np.ndarray]:
+        """Return compression matrix."""
+        pass
+
     def run(self) -> FCBasisSetO1:
         """Compute compressed force constants basis set."""
         c_trans = self._get_c_trans()


### PR DESCRIPTION
Methods of compact_compression_matrix and compression_matrix are added to FCBasisSetO1.py.  FCBasisSetO1 is now compatible with FCBasisSetBase. 