### PR TITLE
Improvement of Symfc class

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,0 +1,38 @@
+name: publish PyPI and TestPyPI
+
+on:
+  push:
+    branches:
+    - master
+    - rc
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.12, ]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Make sdist
+      run: |
+        pip install numpy scipy
+        python setup.py sdist
+    - name: Publish package to TestPyPI
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/rc')
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+    - name: Publish package to PyPI
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/master')
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/src/symfc/basis_sets/basis_sets_base.py
+++ b/src/symfc/basis_sets/basis_sets_base.py
@@ -57,7 +57,16 @@ class FCBasisSetBase(ABC):
     @property
     def translation_permutations(self) -> np.ndarray:
         """Return permutations by lattice translation."""
+        if self._spg_reps is None:
+            raise ValueError("SpgRepsBase is not set.")
         return self._spg_reps.translation_permutations
+
+    @property
+    def p2s_map(self) -> np.ndarray:
+        """Return indices of translationally independent atoms."""
+        if self._spg_reps is None:
+            raise ValueError("SpgRepsBase is not set.")
+        return self._spg_reps._p2s_map
 
     @abstractmethod
     def run(self):

--- a/src/symfc/spg_reps/spg_reps_O1.py
+++ b/src/symfc/spg_reps/spg_reps_O1.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Optional
+
 import numpy as np
 from scipy.sparse import csr_array
 
@@ -13,19 +15,27 @@ from .spg_reps_base import SpgRepsBase
 class SpgRepsO1(SpgRepsBase):
     """Class of reps of space group operations for fc1."""
 
-    def __init__(self, supercell: SymfcAtoms):
+    def __init__(
+        self, supercell: SymfcAtoms, spacegroup_operations: Optional[dict] = None
+    ):
         """Init method.
 
         Parameters
         ----------
         supercell : SymfcAtoms
             Supercell.
+        spacegroup_operations : dict, optional
+            Space group operations in supercell, by default None. When None,
+            spglib is used. The following keys and values correspond to spglib
+            symmetry dataset:
+                rotations : array_like
+                translations : array_like
 
         """
         self._r1_reps: list[csr_array]
         self._col: np.ndarray
         self._data: np.ndarray
-        super().__init__(supercell)
+        super().__init__(supercell, spacegroup_operations=spacegroup_operations)
 
     @property
     def r_reps(self) -> list[csr_array]:
@@ -44,8 +54,8 @@ class SpgRepsO1(SpgRepsBase):
         data, row, col, shape = self._get_sigma1_rep_data(i)
         return csr_array((data, (row, col)), shape=shape)
 
-    def _prepare(self):
-        super()._prepare()
+    def _prepare(self, spacegroup_operations):
+        super()._prepare(spacegroup_operations)
         N = len(self._numbers)
         self._col = np.arange(N, dtype=int)
         self._data = np.ones(N, dtype=int)

--- a/src/symfc/spg_reps/spg_reps_O2.py
+++ b/src/symfc/spg_reps/spg_reps_O2.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Optional
+
 import numpy as np
 from scipy.sparse import csr_array
 
@@ -13,19 +15,27 @@ from .spg_reps_base import SpgRepsBase
 class SpgRepsO2(SpgRepsBase):
     """Class of reps of space group operations for fc2."""
 
-    def __init__(self, supercell: SymfcAtoms):
+    def __init__(
+        self, supercell: SymfcAtoms, spacegroup_operations: Optional[dict] = None
+    ):
         """Init method.
 
         Parameters
         ----------
         supercell : SymfcAtoms
             Supercell.
+        spacegroup_operations : dict, optional
+            Space group operations in supercell, by default None. When None,
+            spglib is used. The following keys and values correspond to spglib
+            symmetry dataset:
+                rotations : array_like
+                translations : array_like
 
         """
         self._r2_reps: list[csr_array]
         self._col: np.ndarray
         self._data: np.ndarray
-        super().__init__(supercell)
+        super().__init__(supercell, spacegroup_operations=spacegroup_operations)
 
     @property
     def r_reps(self) -> list[csr_array]:
@@ -44,8 +54,8 @@ class SpgRepsO2(SpgRepsBase):
         data, row, col, shape = self._get_sigma2_rep_data(i)
         return csr_array((data, (row, col)), shape=shape)
 
-    def _prepare(self):
-        super()._prepare()
+    def _prepare(self, spacegroup_operations):
+        super()._prepare(spacegroup_operations)
         N = len(self._numbers)
         a = np.arange(N)
         self._atom_pairs = np.stack(np.meshgrid(a, a), axis=-1).reshape(-1, 2)

--- a/src/symfc/spg_reps/spg_reps_O3.py
+++ b/src/symfc/spg_reps/spg_reps_O3.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Optional
+
 import numpy as np
 from scipy.sparse import csr_array
 
@@ -12,19 +14,27 @@ from symfc.utils.utils import SymfcAtoms
 class SpgRepsO3(SpgRepsBase):
     """Class of reps of space group operations for fc3."""
 
-    def __init__(self, supercell: SymfcAtoms):
+    def __init__(
+        self, supercell: SymfcAtoms, spacegroup_operations: Optional[dict] = None
+    ):
         """Init method.
 
         Parameters
         ----------
         supercell : SymfcAtoms
             Supercell.
+        spacegroup_operations : dict, optional
+            Space group operations in supercell, by default None. When None,
+            spglib is used. The following keys and values correspond to spglib
+            symmetry dataset:
+                rotations : array_like
+                translations : array_like
 
         """
         self._r3_reps: list[csr_array]
         self._col: np.ndarray
         self._data: np.ndarray
-        super().__init__(supercell)
+        super().__init__(supercell, spacegroup_operations=spacegroup_operations)
 
     @property
     def r_reps(self) -> list[csr_array]:
@@ -43,8 +53,8 @@ class SpgRepsO3(SpgRepsBase):
         data, row, col, shape = self._get_sigma3_rep_data(i)
         return csr_array((data, (row, col)), shape=shape)
 
-    def _prepare(self):
-        super()._prepare()
+    def _prepare(self, spacegroup_operations):
+        super()._prepare(spacegroup_operations)
         N = len(self._numbers)
         a = np.arange(N)
         self._atom_triplets = np.stack(np.meshgrid(a, a, a), axis=-1).reshape(-1, 3)


### PR DESCRIPTION
1. `SpgReps` classes can get `spacegroup_operations` as an init parameter to avoid running symmetry finding. If `spacegroup_operations=None`, spglib symmetry search is performed as before.
2. For (1), `FCBasisSets` classes were changed to get `spacegroup_operations` to pass it to SpgReps` classes.
3. Added `p2s_map` attribute to `FCBasisSets`
4. Added `verbose=True` parameter in  functions `run_solver_sparse_O2` and `_get_training`.