### PR TITLE
rep_nonzero was added to spg_reps_O3

### DIFF
--- a/src/symfc/spg_reps/spg_reps_O3.py
+++ b/src/symfc/spg_reps/spg_reps_O3.py
@@ -53,6 +53,20 @@ class SpgRepsO3(SpgRepsBase):
         data, row, col, shape = self._get_sigma3_rep_data(i)
         return csr_array((data, (row, col)), shape=shape)
 
+    def get_sigma3_rep_nonzero(self, i: int) -> csr_array:
+        """Compute and return nonzero rows and columns.
+
+        Rows and columns of i-th atomic pair permutation matrix.
+
+        Parameters
+        ----------
+        i : int
+            Index of coset presentations of space group operations.
+
+        """
+        _, row, col, _ = self._get_sigma3_rep_data(i)
+        return row, col
+
     def _prepare(self, spacegroup_operations):
         super()._prepare(spacegroup_operations)
         N = len(self._numbers)


### PR DESCRIPTION
get_sigma3_rep_nonzero is added to spg_reps_O3.py. This is used to calculate dot products of coset representative permutation matrix and other matrices using numpy slicing.