### PR TITLE
Efficient algorithm for FC2 basis set

### DIFF
--- a/src/symfc/basis_sets/basis_sets_O2.py
+++ b/src/symfc/basis_sets/basis_sets_O2.py
@@ -22,7 +22,7 @@ from symfc.utils.utils import SymfcAtoms
 from symfc.utils.utils_O2 import (
     _get_atomic_lat_trans_decompr_indices,
     get_compr_coset_projector_O2,
-    get_lat_trans_compr_matrix,
+    get_lat_trans_compr_matrix_O2,
 )
 
 from .basis_sets_base import FCBasisSetBase
@@ -108,7 +108,7 @@ class FCBasisSetO2(FCBasisSetBase):
 
         """
         trans_perms = self._spg_reps.translation_permutations
-        c_trans = get_lat_trans_compr_matrix(trans_perms)
+        c_trans = get_lat_trans_compr_matrix_O2(trans_perms)
         return dot_product_sparse(
             c_trans, self._n_a_compression_matrix, use_mkl=self._use_mkl
         )

--- a/src/symfc/basis_sets/basis_sets_O2.py
+++ b/src/symfc/basis_sets/basis_sets_O2.py
@@ -8,36 +8,40 @@ import numpy as np
 from scipy.sparse import csr_array
 
 from symfc.spg_reps import SpgRepsO2
+from symfc.utils.cutoff_tools import FCCutoff
 from symfc.utils.eig_tools import (
     dot_product_sparse,
     eigsh_projector,
     eigsh_projector_sumrule,
 )
-from symfc.utils.matrix_tools_O2 import compressed_projector_sum_rules
+from symfc.utils.matrix_tools_O2 import (
+    compressed_projector_sum_rules_O2,
+    projector_permutation_lat_trans_O2,
+)
 from symfc.utils.utils import SymfcAtoms
 from symfc.utils.utils_O2 import (
     _get_atomic_lat_trans_decompr_indices,
-    get_compr_coset_reps_sum,
+    get_compr_coset_projector_O2,
     get_lat_trans_compr_matrix,
-    get_lat_trans_decompr_indices,
-    get_perm_compr_matrix,
 )
 
 from .basis_sets_base import FCBasisSetBase
 
 
 class FCBasisSetO2(FCBasisSetBase):
-    """Dense symmetry adapted basis set for 2nd order force constants.
+    r"""Symmetry adapted basis set for 2nd order force constants.
 
     Attributes
     ----------
     basis_set : ndarray
-        Compressed force constants basis set. The first dimension n_x (< n_a) is
-        given as a result of compression, which is depends on the system.
-        shape=(n_x * N * 9, n_bases), dtype='double'
-    full_basis_set : ndarray
-        Full (decompressed) force constants basis set. shape=(N * N * 9,
-        n_bases), dtype='double'
+        Compressed force constants basis set. The first dimension n_compr
+        (<< 9 * N ** 2, \sim n_bases) is given as a result of compression,
+        which depends on the system.  shape=(n_compr, n_bases), dtype='double'
+    n_a_compression_matrix : csr_array
+        Compression matrix compressed by lattice translation. The basis set
+        compressed only by lattice translation is obtained by
+        n_a_compression_matrix @ basis_set.
+        shape=(n_a * N * 9, n_compr), dtype='double'
     translation_permutations : ndarray
         Atom indices after lattice translations. shape=(lattice_translations,
         supercell_atoms), dtype=int.
@@ -47,6 +51,7 @@ class FCBasisSetO2(FCBasisSetBase):
     def __init__(
         self,
         supercell: SymfcAtoms,
+        cutoff: Optional[float] = None,
         spacegroup_operations: Optional[dict] = None,
         use_mkl: bool = False,
         log_level: int = 0,
@@ -57,6 +62,8 @@ class FCBasisSetO2(FCBasisSetBase):
         ----------
         supercell : SymfcAtoms
             Supercell.
+        cutoff: float
+            Cutoff distance in angstroms. Default is None.
         spacegroup_operations : dict, optional
             Space group operations in supercell, by default None. When None,
             spglib is used. The following keys and values correspond to spglib
@@ -73,20 +80,22 @@ class FCBasisSetO2(FCBasisSetBase):
         self._spg_reps = SpgRepsO2(
             supercell, spacegroup_operations=spacegroup_operations
         )
-        self._n_a_compression_matrix: Optional[csr_array] = None
+        if cutoff is None:
+            self._fc_cutoff = None
+        else:
+            self._fc_cutoff = FCCutoff(supercell, cutoff=cutoff)
 
         trans_perms = self._spg_reps.translation_permutations
         self._atomic_decompr_idx = _get_atomic_lat_trans_decompr_indices(trans_perms)
+
+        self._n_a_compression_matrix: Optional[csr_array] = None
+        self._basis_set: Optional[np.ndarray] = None
 
     @property
     def basis_set(self) -> Optional[np.ndarray]:
         """Return compressed basis set.
 
-        n_c = len(compressed_indices).
-
-        shape=(n_c*N*3*3, n_bases), dtype='double'.
-
-        Data in first dimension is ordered by (n_c,N,3,3).
+        shape=(n_c, n_bases), dtype='double'.
 
         """
         return self._basis_set
@@ -98,7 +107,8 @@ class FCBasisSetO2(FCBasisSetBase):
         This expands fc basis_sets to (N*N*3*3, n_bases).
 
         """
-        c_trans = self._get_c_trans()
+        trans_perms = self._spg_reps.translation_permutations
+        c_trans = get_lat_trans_compr_matrix(trans_perms)
         return dot_product_sparse(
             c_trans, self._n_a_compression_matrix, use_mkl=self._use_mkl
         )
@@ -107,83 +117,50 @@ class FCBasisSetO2(FCBasisSetBase):
     def compact_compression_matrix(self) -> Optional[csr_array]:
         """Return compact compression matrix.
 
-        This expands basis_sets to (n_a*N*3*3, n_bases).
+        This expands fc basis_sets to (n_a*N*3*3, n_bases).
 
         """
         n_lp = self.translation_permutations.shape[0]
         return self._n_a_compression_matrix / np.sqrt(n_lp)
 
     @property
-    def decompression_indices(self) -> np.ndarray:
-        """Return decompression indices in (N,N,3,3) order."""
-        trans_perms = self.translation_permutations
-        return get_lat_trans_decompr_indices(trans_perms)
-
-    @property
     def atomic_decompr_idx(self) -> np.ndarray:
-        """Return atomic permutation."""
+        """Return atomic permutations by lattice translations."""
         return self._atomic_decompr_idx
 
     def run(self) -> FCBasisSetO2:
-        """Compute compressed force constants basis set.
-
-        compression using C(pt)
-            = eigvecs of C(trans).T @ C(perm) @ C(perm).T @ C(trans)
-        proj_rpt = c_pt.transpose() @ coset_reps_sum @ c_pt
-
-        [C_pt @ C_trans.T] @ P_sum @ [C_trans @ C_pt] @ C_rpt
-         = C_rpt @ [C_rpt.T @ C_pt @ C_trans.T] @ P_sum @ [C_trans @ C_pt @ C_rpt]
-         = C_rpt @ compression_mat.T @ (I - P_sum^(c)) @ compression_mat
-         = C_rpt @ compression_mat.T @ (I - Csum(c) @ Csum(c).T) @ compression_mat
-         = C_rpt @ proj
-
-        compress_mat = c_trans @ c_pt @ c_rpt
-
-        """
-        N = self._natom
-        c_trans = self._get_c_trans()
-        n_a_compress_mat = self._get_n_a_compress_mat(c_trans)
-        compress_mat = dot_product_sparse(
-            c_trans, n_a_compress_mat, use_mkl=self._use_mkl
+        """Compute compressed force constants basis set."""
+        trans_perms = self._spg_reps.translation_permutations
+        proj_pt = projector_permutation_lat_trans_O2(
+            trans_perms,
+            atomic_decompr_idx=self._atomic_decompr_idx,
+            fc_cutoff=self._fc_cutoff,
+            use_mkl=self._use_mkl,
+            verbose=self._log_level > 0,
         )
-        proj = compressed_projector_sum_rules(compress_mat, N, use_mkl=self._use_mkl)
-        eigvecs = eigsh_projector_sumrule(proj, verbose=self._log_level > 0)
 
-        if self._log_level:
-            print(f"Final size of basis set: {eigvecs.shape}", flush=True)
+        c_pt = eigsh_projector(proj_pt, verbose=self._log_level > 0)
+        proj_rpt = get_compr_coset_projector_O2(
+            self._spg_reps,
+            fc_cutoff=self._fc_cutoff,
+            atomic_decompr_idx=self._atomic_decompr_idx,
+            c_pt=c_pt,
+            # verbose=self._log_level > 0,
+        )
+        c_rpt = eigsh_projector(proj_rpt, verbose=self._log_level > 0)
+        n_a_compress_mat = dot_product_sparse(c_pt, c_rpt, use_mkl=self._use_mkl)
+
+        proj = compressed_projector_sum_rules_O2(
+            trans_perms,
+            n_a_compress_mat,
+            atomic_decompr_idx=self._atomic_decompr_idx,
+            fc_cutoff=self._fc_cutoff,
+            use_mkl=self._use_mkl,
+            # verbose=self._log_level > 0,
+        )
+        eigvecs = eigsh_projector_sumrule(proj, verbose=self._log_level > 0)
 
         self._basis_set = eigvecs
         self._n_a_compression_matrix = n_a_compress_mat
+
         return self
-
-    def _get_n_a_compress_mat(self, c_trans: csr_array) -> csr_array:
-        """Return compression matrix without c_trans mutiplied.
-
-        This compression matrix is preserved as a class instance variable.
-        The full compression matrix is obtained by
-
-        c_trans @ n_a_compression_matrix.
-
-        The compact compression matrix is obtained by
-
-        n_a_compression_matrix / sqrt(n_lp).
-
-        """
-        N = self._natom
-        c_perm = get_perm_compr_matrix(N)
-        c_pt = dot_product_sparse(c_perm.T, c_trans, use_mkl=self._use_mkl)
-        proj_pt = dot_product_sparse(c_pt.T, c_pt, use_mkl=self._use_mkl)
-        coset_reps_sum = get_compr_coset_reps_sum(self._spg_reps)
-        c_pt = eigsh_projector(proj_pt, verbose=self._log_level > 0)
-        proj_rpt = dot_product_sparse(coset_reps_sum, c_pt, use_mkl=self._use_mkl)
-        proj_rpt = dot_product_sparse(c_pt.T, proj_rpt)
-        c_rpt = eigsh_projector(proj_rpt, verbose=self._log_level > 0)
-        n_a_compress_mat = dot_product_sparse(c_pt, c_rpt, use_mkl=self._use_mkl)
-        return n_a_compress_mat
-
-    def _get_c_trans(self) -> csr_array:
-        trans_perms = self._spg_reps.translation_permutations
-        n_lp, N = trans_perms.shape
-        decompr_idx = get_lat_trans_decompr_indices(trans_perms)
-        c_trans = get_lat_trans_compr_matrix(decompr_idx, N, n_lp)
-        return c_trans

--- a/src/symfc/basis_sets/basis_sets_O4.py
+++ b/src/symfc/basis_sets/basis_sets_O4.py
@@ -30,29 +30,29 @@ from . import FCBasisSetBase
 
 
 class FCBasisSetO4(FCBasisSetBase):
-    """Symmetry adapted basis set for 4th order force constants.
+    r"""Symmetry adapted basis set for 4th order force constants.
 
     Attributes
     ----------
     basis_set : ndarray
-        Compressed force constants basis set.
-        shape=(n_a * N * N * N * 81, n_bases), dtype='double'
-    full_basis_set : ndarray
-        Full (decompressed) force constants basis set.
-        shape=(N * N * N * N * 81, n_bases), dtype='double'
-    atomic_decompression_indices : ndarray
-        Decompression indices in (N,N,N,N) order.
-        shape=(N**4,), dtype='int_'.
+        Compressed force constants basis set. The first dimension n_compr
+        (<< 81 * N ** 4, \sim n_bases) is given as a result of compression,
+        which depends on the system.  shape=(n_compr, n_bases), dtype='double'
+    n_a_compression_matrix : csr_array
+        Compression matrix compressed by lattice translation. The basis set
+        compressed only by lattice translation is obtained by
+        n_a_compression_matrix @ basis_set.
+        shape=(n_a * N * N * N * 81, n_compr), dtype='double'
     translation_permutations : ndarray
-        Atom indices after lattice translations.
-        shape=(lattice_translations, supercell_atoms), dtype=int.
+        Atom indices after lattice translations. shape=(lattice_translations,
+        supercell_atoms), dtype=int.
 
     """
 
     def __init__(
         self,
         supercell: SymfcAtoms,
-        cutoff: float = None,
+        cutoff: Optional[float] = None,
         spacegroup_operations: Optional[dict] = None,
         use_mkl: bool = False,
         log_level: int = 0,
@@ -63,12 +63,16 @@ class FCBasisSetO4(FCBasisSetBase):
         ----------
         supercell : SymfcAtoms
             Supercell.
+        cutoff: float
+            Cutoff distance in angstroms. Default is None.
         spacegroup_operations : dict, optional
             Space group operations in supercell, by default None. When None,
             spglib is used. The following keys and values correspond to spglib
             symmetry dataset:
                 rotations : array_like
                 translations : array_like
+        use_mkl : bool
+            Use MKL or not. Default is False.
         log_level : int, optional
             Log level. Default is 0.
 
@@ -85,15 +89,14 @@ class FCBasisSetO4(FCBasisSetBase):
         trans_perms = self._spg_reps.translation_permutations
         self._atomic_decompr_idx = get_atomic_lat_trans_decompr_indices_O4(trans_perms)
 
+        self._n_a_compression_matrix: Optional[csr_array] = None
+        self._basis_set: Optional[np.ndarray] = None
+
     @property
-    def basis_set(self) -> Optional[csr_array]:
+    def basis_set(self) -> Optional[np.ndarray]:
         """Return compressed basis set.
 
-        n_c = len(compressed_indices).
-
-        shape=(n_c*N*N*N*3*3*3*3, n_bases), dtype='double'.
-
-        Data in first dimension is ordered by (n_c,N,N,N,3,3,3,3).
+        shape=(n_c, n_bases), dtype='double'.
 
         """
         return self._basis_set
@@ -115,7 +118,7 @@ class FCBasisSetO4(FCBasisSetBase):
     def compact_compression_matrix(self) -> Optional[csr_array]:
         """Return compact compression matrix.
 
-        This expands basis_sets to (n_a*N*N*N*3*3*3*3, n_bases).
+        This expands fc basis_sets to (n_a*N*N*N*3*3*3*3, n_bases).
 
         """
         n_lp = self.translation_permutations.shape[0]
@@ -123,7 +126,7 @@ class FCBasisSetO4(FCBasisSetBase):
 
     @property
     def atomic_decompr_idx(self) -> np.ndarray:
-        """Return atomic permutation."""
+        """Return atomic permutations by lattice translations."""
         return self._atomic_decompr_idx
 
     def run(self) -> FCBasisSetO4:

--- a/src/symfc/spg_reps/spg_reps_O2.py
+++ b/src/symfc/spg_reps/spg_reps_O2.py
@@ -33,6 +33,86 @@ class SpgRepsO2(SpgRepsBase):
 
         """
         self._r2_reps: list[csr_array]
+        super().__init__(supercell, spacegroup_operations=spacegroup_operations)
+
+    @property
+    def r_reps(self) -> list[csr_array]:
+        """Return 2nd rank tensor rotation matricies."""
+        return self._r2_reps
+
+    def get_sigma2_rep(self, i: int, nonzero: np.ndarray = None) -> csr_array:
+        """Compute vector representation of i-th atomic pair permutation matrix.
+
+        Parameters
+        ----------
+        i : int
+            Index of coset presentations of space group operations.
+
+        """
+        return self._get_sigma2_rep_data(i, nonzero=nonzero)
+
+    def _prepare(self, spacegroup_operations):
+        super()._prepare(spacegroup_operations)
+        N = len(self._numbers)
+        self._atom_pairs = (np.mgrid[0:N, 0:N].reshape((2, -1)).T).astype(
+            "uint16", copy=False
+        )
+        self._coeff = np.array([N, 1], dtype=int)
+        self._compute_r2_reps()
+
+    def _compute_r2_reps(self, tol: float = 1e-10):
+        """Compute and return 2nd rank tensor rotation matricies."""
+        r2_reps = []
+        for r in self._unique_rotations:
+            r_c = self._lattice.T @ r @ np.linalg.inv(self._lattice.T)
+            r2_rep = np.kron(r_c, r_c)
+            row, col = np.nonzero(np.abs(r2_rep) > tol)
+            data = r2_rep[(row, col)]
+            r2_reps.append(csr_array((data, (row, col)), shape=r2_rep.shape))
+        self._r2_reps = r2_reps
+
+    def _get_sigma2_rep_data(self, i: int, nonzero: np.ndarray = None) -> csr_array:
+        """Compute vector representation of i-th atomic pair permutation matrix.
+
+        Operation permutation[self._atom_pairs @ self._coeff is divided
+        to reduce memory allocation.
+
+        permutation_pairs represents row indices of nonzero elements
+        in permutation matrix. Column indices of nonzero elements in permutation
+        matrix are array indices of permutation_pairs.
+        """
+        uri = self._unique_rotation_indices
+        permutation = self._permutations[uri[i]]
+        if nonzero is not None:
+            pairs = self._atom_pairs[nonzero]
+        else:
+            pairs = self._atom_pairs
+        permutation_pairs = permutation[pairs[:, 0]] * self._coeff[0]
+        permutation_pairs += permutation[pairs[:, 1]]
+        return permutation_pairs
+
+
+class SpgRepsO2MatrixReps(SpgRepsBase):
+    """Class of reps of space group operations for fc2."""
+
+    def __init__(
+        self, supercell: SymfcAtoms, spacegroup_operations: Optional[dict] = None
+    ):
+        """Init method.
+
+        Parameters
+        ----------
+        supercell : SymfcAtoms
+            Supercell.
+        spacegroup_operations : dict, optional
+            Space group operations in supercell, by default None. When None,
+            spglib is used. The following keys and values correspond to spglib
+            symmetry dataset:
+                rotations : array_like
+                translations : array_like
+
+        """
+        self._r2_reps: list[csr_array]
         self._col: np.ndarray
         self._data: np.ndarray
         super().__init__(supercell, spacegroup_operations=spacegroup_operations)

--- a/src/symfc/spg_reps/spg_reps_O3.py
+++ b/src/symfc/spg_reps/spg_reps_O3.py
@@ -76,6 +76,10 @@ class SpgRepsO3(SpgRepsBase):
 
         Operation permutation[self._atom_triplets] @ self._coeff is divided
         to reduce memory allocation.
+
+        permutation_triplets represents row indices of nonzero elements
+        in permutation matrix. Column indices of nonzero elements in permutation
+        matrix are array indices of permutation_triplets.
         """
         uri = self._unique_rotation_indices
         permutation = self._permutations[uri[i]]

--- a/src/symfc/spg_reps/spg_reps_O4.py
+++ b/src/symfc/spg_reps/spg_reps_O4.py
@@ -76,6 +76,10 @@ class SpgRepsO4(SpgRepsBase):
 
         Operation permutation[self._atom_quadruplets] @ self._coeff is divided
         to reduce memory allocation.
+
+        permutation_quadruplets represents row indices of nonzero elements
+        in permutation matrix. Column indices of nonzero elements in permutation
+        matrix are array indices of permutation_quadruplets.
         """
         uri = self._unique_rotation_indices
         permutation = self._permutations[uri[i]]

--- a/src/symfc/spg_reps/spg_reps_base.py
+++ b/src/symfc/spg_reps/spg_reps_base.py
@@ -72,14 +72,9 @@ class SpgRepsBase:
             self._unique_rotation_indices,
             self._unique_rotations,
         ) = self._get_unique_rotation_indices(rotations)
-        import time
-
-        t1 = time.time()
         self._permutations = compute_sg_permutations(
             self._positions, rotations, translations, self._lattice.T, 1e-5
         )
-        t2 = time.time()
-        print("SG_Permutations:", t2 - t1, "(s)")
         self._translation_permutations = self._get_translation_permutations(rotations)
         self._p2s_map = get_indep_atoms_by_lat_trans(self._translation_permutations)
 

--- a/src/symfc/spg_reps/spg_reps_base.py
+++ b/src/symfc/spg_reps/spg_reps_base.py
@@ -72,9 +72,14 @@ class SpgRepsBase:
             self._unique_rotation_indices,
             self._unique_rotations,
         ) = self._get_unique_rotation_indices(rotations)
+        import time
+
+        t1 = time.time()
         self._permutations = compute_sg_permutations(
             self._positions, rotations, translations, self._lattice.T, 1e-5
         )
+        t2 = time.time()
+        print("SG_Permutations:", t2 - t1, "(s)")
         self._translation_permutations = self._get_translation_permutations(rotations)
         self._p2s_map = get_indep_atoms_by_lat_trans(self._translation_permutations)
 

--- a/src/symfc/utils/matrix_tools_O3.py
+++ b/src/symfc/utils/matrix_tools_O3.py
@@ -1,14 +1,20 @@
 """Matrix utility functions for 3rd order force constants."""
 
+from typing import Optional
+
 import numpy as np
 import scipy
 from scipy.sparse import csr_array, vstack
 
 from symfc.utils.cutoff_tools import FCCutoff
-from symfc.utils.eig_tools import dot_product_sparse
 from symfc.utils.matrix_tools import get_combinations
 from symfc.utils.solver_funcs import get_batch_slice
 from symfc.utils.utils_O3 import get_atomic_lat_trans_decompr_indices_O3
+
+try:
+    from symfc.utils.eig_tools import dot_product_sparse
+except ImportError:
+    pass
 
 
 def N3N3N3_to_NNNand333(combs: np.ndarray, N: int) -> np.ndarray:
@@ -27,9 +33,9 @@ def N3N3N3_to_NNNand333(combs: np.ndarray, N: int) -> np.ndarray:
 
 def projector_permutation_lat_trans_O3(
     trans_perms: np.ndarray,
-    atomic_decompr_idx: np.ndarray = None,
-    fc_cutoff: FCCutoff = None,
-    n_batch: int = None,
+    atomic_decompr_idx: Optional[np.ndarray] = None,
+    fc_cutoff: Optional[FCCutoff] = None,
+    n_batch: Optional[int] = None,
     use_mkl: bool = False,
     verbose: bool = False,
 ):
@@ -45,7 +51,7 @@ def projector_permutation_lat_trans_O3(
         dtype='intc'.
         shape=(n_l, N), where n_l and N are the numbers of lattce points and
         atoms in supercell.
-    fc_cutoff : FCCutoff
+    fc_cutoff : FCCutoff class object. Default is None.
 
     Return
     ------
@@ -151,7 +157,7 @@ def projector_permutation_lat_trans_O3(
         )
 
         c_pt = c_pt_batch if c_pt is None else vstack([c_pt, c_pt_batch])
-        if len(c_pt.data) > 2147483647 / 4:
+        if len(c_pt.data) > 2147483647 // 4:
             if verbose:
                 print("Executed: proj_pt += c_pt.T @ c_pt", flush=True)
             proj_pt += dot_product_sparse(c_pt.T, c_pt, use_mkl=use_mkl)
@@ -159,16 +165,17 @@ def projector_permutation_lat_trans_O3(
 
     if c_pt is not None:
         proj_pt += dot_product_sparse(c_pt.T, c_pt, use_mkl=use_mkl)
+
     return proj_pt
 
 
 def compressed_projector_sum_rules_O3(
-    trans_perms,
+    trans_perms: np.ndarray,
     n_a_compress_mat: csr_array,
-    fc_cutoff: FCCutoff = None,
-    atomic_decompr_idx: np.ndarray = None,
+    atomic_decompr_idx: Optional[np.ndarray] = None,
+    fc_cutoff: Optional[FCCutoff] = None,
+    n_batch: Optional[int] = None,
     use_mkl: bool = False,
-    n_batch: int = None,
     verbose: bool = False,
 ) -> csr_array:
     """Return projection matrix for sum rule.

--- a/src/symfc/utils/matrix_tools_O3.py
+++ b/src/symfc/utils/matrix_tools_O3.py
@@ -151,8 +151,14 @@ def projector_permutation_lat_trans_O3(
         )
 
         c_pt = c_pt_batch if c_pt is None else vstack([c_pt, c_pt_batch])
+        if len(c_pt.data) > 2147483647 / 4:
+            if verbose:
+                print("Executed: proj_pt += c_pt.T @ c_pt", flush=True)
+            proj_pt += dot_product_sparse(c_pt.T, c_pt, use_mkl=use_mkl)
+            c_pt = None
 
-    proj_pt += dot_product_sparse(c_pt.T, c_pt, use_mkl=use_mkl)
+    if c_pt is not None:
+        proj_pt += dot_product_sparse(c_pt.T, c_pt, use_mkl=use_mkl)
     return proj_pt
 
 

--- a/src/symfc/utils/utils.py
+++ b/src/symfc/utils/utils.py
@@ -34,6 +34,14 @@ def get_indep_atoms_by_lat_trans(trans_perms: np.ndarray) -> np.ndarray:
     return np.array(unique_atoms, dtype=int)
 
 
+def round_positions(positions, tol=1e-13, decimals=10):
+    """Round fractional coordinates of positions (-0.5 < p <= 0.5)."""
+    positions_rint = positions - np.rint(positions)
+    positions_rint[np.abs(positions_rint + 0.5) < tol] = 0.5
+    positions_rint = np.round(positions_rint, decimals)
+    return positions_rint
+
+
 def compute_sg_permutations(
     positions: np.ndarray,
     rotations: np.ndarray,
@@ -71,6 +79,100 @@ def compute_sg_permutations(
     """
     trans_perms = []
     pure_trans = []
+    n_atom = positions.shape[0]
+    positions_rint = [tuple(p) for p in round_positions(positions)]
+    sorted_ids = sorted(range(n_atom), key=positions_rint.__getitem__)
+    for r, t in zip(rotations, translations):
+        if (r != np.eye(3, dtype=int)).any():
+            continue
+        trans_positions = [tuple(p) for p in round_positions(positions + t)]
+        sorted_ids_trans = sorted(range(n_atom), key=trans_positions.__getitem__)
+        tp = np.zeros(n_atom, dtype=int)
+        tp[sorted_ids] = sorted_ids_trans
+        trans_perms.append(tp)
+        pure_trans.append(t)
+    trans_perms = np.array(trans_perms, dtype=int)
+    pure_trans = np.array(pure_trans)
+
+    unique_r = []
+    unique_t = []
+    r2ur = []
+    unique_rotated_positions = []
+    for r, t in zip(rotations, translations):
+        is_found = False
+        for j, ur in enumerate(unique_r):
+            if (r == ur).all():
+                is_found = True
+                r2ur.append(j)
+                break
+        if not is_found:
+            r2ur.append(len(unique_r))
+            unique_r.append(r)
+            unique_t.append(t)
+            unique_rotated_positions.append(positions @ r.T + t)
+
+    unique_rotation_perms = []
+    for rotated_positions in unique_rotated_positions:
+        diffs = positions[None, :, :] - rotated_positions[:, None, :]
+        diffs -= np.rint(diffs)
+        dists = np.linalg.norm(diffs @ lattice.T, axis=2)
+        rows, cols = np.where(dists < symprec)
+        assert len(positions) == len(np.unique(rows)) == len(np.unique(cols))
+        unique_rotation_perms.append(cols[np.argsort(rows)])
+    unique_rotation_perms = np.array(unique_rotation_perms, dtype=int)
+
+    out = []
+    for i, t in enumerate(translations):
+        perms = unique_rotation_perms[r2ur[i]]
+        lattice_trans = t - unique_t[r2ur[i]]
+        diffs = pure_trans - lattice_trans
+        diffs -= np.rint(diffs)
+        dists = np.linalg.norm(diffs @ lattice.T, axis=1)
+        lat_trans_idx = np.where(dists < symprec)
+        assert len(lat_trans_idx) == 1
+        out.append(trans_perms[lat_trans_idx[0], perms])
+    out = np.array(out, dtype="intc", order="C")
+    return out
+
+
+def compute_sg_permutations_stable(
+    positions: np.ndarray,
+    rotations: np.ndarray,
+    translations: np.ndarray,
+    lattice: np.ndarray,
+    symprec: float = 1e-5,
+) -> np.ndarray:
+    """Compute permutations of atoms by space group operations in supercell.
+
+    Permutations of atoms of pure translations and coset representatives are
+    first computed. Then permutations of atoms of all the given space group
+    operations are made as the combitation of these two permutations.
+
+    Parameters
+    ----------
+    positions : ndarray
+        Fractional positions (like SymfcAtoms.scaled_positions) before applying
+        the space group operation.
+    rotations : ndarray
+        Matrix (rotation) parts of space group operations.
+        shape=(len(operations), 3, 3), dtype='intc'
+    translations : ndarray
+        Vector (translation) parts of space group operations.
+        shape=(len(operations), 3), dtype='double'
+    lattice : ndarray
+        Basis vectors in column vectors (like SymfcAtoms.cell.T).
+    symprec : float
+        Symmetry tolerance of the distance unit.
+
+    Returns
+    -------
+    perms : ndarray
+        shape=(len(translations), len(positions)), dtype='intc', order='C'
+
+    """
+    trans_perms = []
+    pure_trans = []
+    """Bottleneck part"""
     for r, t in zip(rotations, translations):
         if (r != np.eye(3, dtype=int)).any():
             continue

--- a/src/symfc/utils/utils_O2.py
+++ b/src/symfc/utils/utils_O2.py
@@ -119,6 +119,14 @@ def get_lat_trans_compr_matrix(decompr_idx: np.ndarray, N: int, n_lp: int) -> cs
     return compression_mat
 
 
+def get_lat_trans_compr_matrix_O2(trans_perms: np.ndarray):
+    """Return lat trans compression matrix."""
+    n_lp, N = trans_perms.shape
+    decompr_idx = get_lat_trans_decompr_indices(trans_perms)
+    c_trans = get_lat_trans_compr_matrix(decompr_idx, N, n_lp)
+    return c_trans
+
+
 def get_perm_compr_matrix(natom: int) -> csr_array:
     """Return compression matrix by permutation symmetry.
 

--- a/src/symfc/utils/utils_O2.py
+++ b/src/symfc/utils/utils_O2.py
@@ -1,30 +1,15 @@
 """Utility functions for 2nd order force constants."""
 
 import itertools
+from typing import Optional
 
 import numpy as np
 from scipy.sparse import csr_array, kron
 
 from symfc.spg_reps import SpgRepsO2
+from symfc.utils.cutoff_tools import FCCutoff
 
 from .utils import get_indep_atoms_by_lat_trans
-
-
-def get_spg_perm_projector(spg_reps: SpgRepsO2, decompr_idx: np.ndarray) -> csr_array:
-    """Compute compact spg+perm projector matrix using kron.
-
-    This computes C.T @ spg_proj @ perm_proj @ C, where C is
-    ``compression_mat``.
-
-    """
-    trans_perms = spg_reps.translation_permutations
-    n_lp, N = trans_perms.shape
-    compression_mat = get_lat_trans_compr_matrix(decompr_idx, N, n_lp)
-    coset_reps_sum = get_compr_coset_reps_sum(spg_reps)
-    C_perm = get_perm_compr_matrix(N)
-    perm = C_perm.T @ compression_mat
-    perm = perm.T @ perm
-    return coset_reps_sum @ perm
 
 
 def get_lat_trans_decompr_indices(trans_perms: np.ndarray) -> np.ndarray:
@@ -279,3 +264,56 @@ def _get_perm_compr_matrix_reference(natom: int) -> csr_array:
     else:
         assert ((natom * 3) // 2) * (natom * 3 + 1) == n, f"{natom}, {n}"
     return csr_array((data, (row, col)), shape=(size_row, n), dtype="double")
+
+
+def get_compr_coset_projector_O2(
+    spg_reps: SpgRepsO2,
+    atomic_decompr_idx: Optional[np.ndarray] = None,
+    fc_cutoff: Optional[FCCutoff] = None,
+    c_pt: Optional[csr_array] = None,
+) -> csr_array:
+    """Return compr matrix of sum of coset reps."""
+    trans_perms = spg_reps.translation_permutations
+    n_lp, N = trans_perms.shape
+    size = N**2 * 9 // n_lp if c_pt is None else c_pt.shape[1]
+    coset_reps_sum = csr_array((size, size), dtype="double")
+
+    if atomic_decompr_idx is None:
+        atomic_decompr_idx = _get_atomic_lat_trans_decompr_indices(trans_perms)
+
+    if fc_cutoff is None:
+        nonzero = None
+        size_data = N**2
+    else:
+        nonzero = fc_cutoff.nonzero_atomic_indices_fc2()
+        size_data = np.count_nonzero(nonzero)
+
+    factor = 1 / n_lp / len(spg_reps.unique_rotation_indices)
+    for i, _ in enumerate(spg_reps.unique_rotation_indices):
+        permutation = spg_reps.get_sigma2_rep(i, nonzero=nonzero)
+        if nonzero is None:
+            mat = csr_array(
+                (
+                    np.ones(size_data, dtype="int_"),
+                    (atomic_decompr_idx[permutation], atomic_decompr_idx),
+                ),
+                shape=(N**2 // n_lp, N**2 // n_lp),
+                dtype="int_",
+            )
+        else:
+            mat = csr_array(
+                (
+                    np.ones(size_data, dtype="int_"),
+                    (atomic_decompr_idx[permutation], atomic_decompr_idx[nonzero]),
+                ),
+                shape=(N**2 // n_lp, N**2 // n_lp),
+                dtype="int_",
+            )
+
+        mat = kron(mat, spg_reps.r_reps[i] * factor)
+        if c_pt is not None:
+            mat = c_pt.T @ mat @ c_pt
+
+        coset_reps_sum += mat
+
+    return coset_reps_sum

--- a/tests/basis_sets/test_basis_sets_O2.py
+++ b/tests/basis_sets/test_basis_sets_O2.py
@@ -26,6 +26,7 @@ def test_fc_basis_set_o2():
     )
 
     comp_mat = sbs.compression_matrix
+    print(comp_mat)
     np.testing.assert_allclose(comp_mat.data, [0.40824829046386313] * comp_mat.size)
     ref_col = [0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0]
     ref_row = [0, 4, 8, 9, 13, 17, 18, 22, 26, 27, 31, 35]

--- a/tests/spg_reps/test_spg_reps_O2.py
+++ b/tests/spg_reps/test_spg_reps_O2.py
@@ -10,7 +10,10 @@ def test_spg_reps_o2(cell_nacl_111: SymfcAtoms):
     spg_reps_o2 = SpgRepsO2(cell_nacl_111)
     trace_sum = 0
     for i, _ in enumerate(spg_reps_o2.unique_rotation_indices):
-        s_r = spg_reps_o2.get_sigma2_rep(i).toarray()
-        trace_sum += np.trace(s_r)
+        # s_r = spg_reps_o2.get_sigma2_rep(i).toarray()
+        # trace_sum += np.trace(s_r)
+        trace_sum += np.count_nonzero(
+            spg_reps_o2.get_sigma2_rep(i) == np.arange(64, dtype=int)
+        )
 
     assert trace_sum == 960


### PR DESCRIPTION
The followings are implemented.
- Efficient algorithm for FC2 basis set.
- Efficient algorithm for sg_permutations using sort algorithm.
- test_spg_reps_O2.py is changed according to the change of spg_reps_O2.py.
- Slight revision of algorithms for computing perm @ tr. (MKL errors can be avoided in large systems.)