### PR TITLE
Simplify coset and permutation.

### DIFF
--- a/src/symfc/utils/matrix_tools.py
+++ b/src/symfc/utils/matrix_tools.py
@@ -1,9 +1,14 @@
 """Matrix utility functions."""
 
+from typing import Optional
+
 import numpy as np
+from scipy.sparse import csr_array
+
+from symfc.utils.cutoff_tools import FCCutoff
 
 
-def get_combinations(n, r):
+def get_entire_combinations(n, r):
     """Return numpy array of combinations.
 
     combinations = np.array(
@@ -20,3 +25,53 @@ def get_combinations(n, r):
         combs[j, 0] = j
         combs[j] = np.add.accumulate(combs[j])
     return combs.T
+
+
+def get_combinations(natom: int, order: int, fc_cutoff: Optional[FCCutoff] = None):
+    """Return numpy array of FC index combinations."""
+    if fc_cutoff is None:
+        combinations = get_entire_combinations(3 * natom, order)
+    else:
+        if order == 2:
+            combinations = fc_cutoff.combinations2()
+        elif order == 3:
+            """Combinations can be divided using fc_cut.combiations3(i)."""
+            combinations = fc_cutoff.combinations3_all()
+        elif order == 4:
+            combinations = fc_cutoff.combinations4_all()
+        else:
+            raise NotImplementedError(
+                "Combinations are implemented only for 2 <= order <= 4."
+            )
+    return combinations
+
+
+def permutation_dot_lat_trans(
+    combinations_ijk: np.ndarray,
+    combinations_abc: np.ndarray,
+    atomic_decompr_idx: np.ndarray,
+    n_perms: int,
+    n_perms_group: int,
+    n_lp: int,
+    order: int,
+    natom: int,
+) -> csr_array:
+    """Return C_perm.T @ C_trans for permulation symmetry rules."""
+    assert combinations_ijk.shape[0] == combinations_abc.shape[0]
+
+    sum_abc = 3**order
+    sum_ijkabc = natom**order * sum_abc
+    n_combinations = combinations_ijk.shape[0] // n_perms
+    n_perms_sym = n_perms // n_perms_group
+    c_pt = csr_array(
+        (
+            np.full(n_combinations * n_perms, 1 / np.sqrt(n_perms_sym * n_lp)),
+            (
+                np.repeat(np.arange(n_combinations * n_perms_group), n_perms_sym),
+                atomic_decompr_idx[combinations_ijk] * sum_abc + combinations_abc,
+            ),
+        ),
+        shape=(n_combinations * n_perms_group, sum_ijkabc // n_lp),
+        dtype="double",
+    )
+    return c_pt

--- a/src/symfc/utils/matrix_tools_O4.py
+++ b/src/symfc/utils/matrix_tools_O4.py
@@ -8,7 +8,7 @@ import scipy
 from scipy.sparse import csr_array, vstack
 
 from symfc.utils.cutoff_tools import FCCutoff
-from symfc.utils.matrix_tools import get_combinations
+from symfc.utils.matrix_tools import get_combinations, permutation_dot_lat_trans
 from symfc.utils.solver_funcs import get_batch_slice
 from symfc.utils.utils_O4 import get_atomic_lat_trans_decompr_indices_O4
 
@@ -62,36 +62,26 @@ def projector_permutation_lat_trans_O4(
     P_pt = C_trans.T @ C_perm @ C_perm.T @ C_trans
     """
     n_lp, natom = trans_perms.shape
-    NNNN81 = natom**4 * 81
     if atomic_decompr_idx is None:
         atomic_decompr_idx = get_atomic_lat_trans_decompr_indices_O4(trans_perms)
 
-    """(1) for FC4 with single index ia"""
+    """FC4 with single distinct index (ia, ia, ia, ia)"""
     combinations = np.array([[i, i, i, i] for i in range(3 * natom)], dtype=int)
-    n_perm1 = combinations.shape[0]
     combinations, combinations3333 = N3N3N3N3_to_NNNNand3333(combinations, natom)
-
-    c_pt = csr_array(
-        (
-            np.full(n_perm1, 1.0 / np.sqrt(n_lp)),
-            (
-                np.arange(n_perm1),
-                atomic_decompr_idx[combinations] * 81 + combinations3333,
-            ),
-        ),
-        shape=(n_perm1, NNNN81 // n_lp),
-        dtype="double",
+    c_pt = permutation_dot_lat_trans(
+        combinations,
+        combinations3333,
+        atomic_decompr_idx,
+        n_perms=1,
+        n_perms_group=1,
+        n_lp=n_lp,
+        order=4,
+        natom=natom,
     )
     proj_pt = dot_product_sparse(c_pt.T, c_pt, use_mkl=use_mkl)
 
-    """(2) for FC4 with two distinguished indices (ia,ia,ia,jb)"""
-    if fc_cutoff is None:
-        combinations = get_combinations(3 * natom, 2)
-    else:
-        combinations = fc_cutoff.combinations2()
-
-    n_comb2 = combinations.shape[0]
-    n_perm2 = n_comb2 * 2
+    """FC4 with two distinct indices (ia,ia,ia,jb)"""
+    combinations = get_combinations(natom, order=2, fc_cutoff=fc_cutoff)
     perms = [
         [0, 0, 0, 1],
         [0, 0, 1, 0],
@@ -105,20 +95,19 @@ def projector_permutation_lat_trans_O4(
     combinations = combinations[:, perms].reshape((-1, 4))
     combinations, combinations3333 = N3N3N3N3_to_NNNNand3333(combinations, natom)
 
-    c_pt = csr_array(
-        (
-            np.full(n_perm2 * 4, 1 / np.sqrt(4 * n_lp)),
-            (
-                np.repeat(range(n_perm2), 4),
-                atomic_decompr_idx[combinations] * 81 + combinations3333,
-            ),
-        ),
-        shape=(n_perm2, NNNN81 // n_lp),
-        dtype="double",
+    c_pt = permutation_dot_lat_trans(
+        combinations,
+        combinations3333,
+        atomic_decompr_idx,
+        n_perms=len(perms),
+        n_perms_group=2,
+        n_lp=n_lp,
+        order=4,
+        natom=natom,
     )
     proj_pt += dot_product_sparse(c_pt.T, c_pt, use_mkl=use_mkl)
 
-    """(3) for FC4 with three distinguished indices (ia,ia,jb,kc)
+    """FC4 with three distinct indices (ia,ia,jb,kc)
     [
         [a, a, b, c],
         [a, a, c, b],
@@ -137,11 +126,7 @@ def projector_permutation_lat_trans_O4(
     if verbose:
         print("Find combinations of three FC elements", flush=True)
 
-    if fc_cutoff is None:
-        combinations = get_combinations(3 * natom, 3)
-    else:
-        combinations = fc_cutoff.combinations3_all()
-
+    combinations = get_combinations(natom, order=3, fc_cutoff=fc_cutoff)
     n_comb3 = combinations.shape[0]
     perms = [
         [0, 0, 1, 2],
@@ -189,25 +174,21 @@ def projector_permutation_lat_trans_O4(
             print(
                 "Proj (perm.T @ trans, 3):", str(end) + "/" + str(n_comb3), flush=True
             )
-        batch_size = end - begin
-        n_perm3 = batch_size * 3
         combinations_perm = combinations[begin:end][:, perms].reshape((-1, 4))
         combinations_perm, combinations3333 = N3N3N3N3_to_NNNNand3333(
             combinations_perm, natom
         )
-        c_pt_batch = csr_array(
-            (
-                np.full(batch_size * 36, 1 / np.sqrt(12 * n_lp)),
-                (
-                    np.repeat(np.arange(n_perm3), 12),
-                    atomic_decompr_idx[combinations_perm] * 81 + combinations3333,
-                ),
-            ),
-            shape=(n_perm3, NNNN81 // n_lp),
-            dtype="double",
+        c_pt_batch = permutation_dot_lat_trans(
+            combinations_perm,
+            combinations3333,
+            atomic_decompr_idx,
+            n_perms=len(perms),
+            n_perms_group=3,
+            n_lp=n_lp,
+            order=4,
+            natom=natom,
         )
         c_pt = c_pt_batch if c_pt is None else vstack([c_pt, c_pt_batch])
-
         if len(c_pt.data) > 2147483647 / 4:
             if verbose:
                 print("Executed: proj_pt += c_pt.T @ c_pt", flush=True)
@@ -217,15 +198,11 @@ def projector_permutation_lat_trans_O4(
     if c_pt is not None:
         proj_pt += dot_product_sparse(c_pt.T, c_pt, use_mkl=use_mkl)
 
-    """(4) for FC4 with four distinguished indices (ia,jb,kc,ld)"""
+    """FC4 with four distinct indices (ia,jb,kc,ld)"""
     if verbose:
         print("Find combinations of four FC elements", flush=True)
 
-    if fc_cutoff is None:
-        combinations = get_combinations(3 * natom, 4)
-    else:
-        combinations = fc_cutoff.combinations4_all()
-
+    combinations = get_combinations(natom, order=4, fc_cutoff=fc_cutoff)
     n_comb4 = combinations.shape[0]
     perms = np.array(list(itertools.permutations(range(4))))
 
@@ -236,21 +213,19 @@ def projector_permutation_lat_trans_O4(
             print(
                 "Proj (perm.T @ trans, 4):", str(end) + "/" + str(n_comb4), flush=True
             )
-        batch_size = n_perm4 = end - begin
         combinations_perm = combinations[begin:end][:, perms].reshape((-1, 4))
         combinations_perm, combinations3333 = N3N3N3N3_to_NNNNand3333(
             combinations_perm, natom
         )
-        c_pt_batch = csr_array(
-            (
-                np.full(batch_size * 24, 1 / np.sqrt(24 * n_lp)),
-                (
-                    np.repeat(np.arange(n_perm4), 24),
-                    atomic_decompr_idx[combinations_perm] * 81 + combinations3333,
-                ),
-            ),
-            shape=(n_perm4, NNNN81 // n_lp),
-            dtype="double",
+        c_pt_batch = permutation_dot_lat_trans(
+            combinations_perm,
+            combinations3333,
+            atomic_decompr_idx,
+            n_perms=len(perms),
+            n_perms_group=1,
+            n_lp=n_lp,
+            order=4,
+            natom=natom,
         )
         c_pt = c_pt_batch if c_pt is None else vstack([c_pt, c_pt_batch])
 
@@ -262,7 +237,6 @@ def projector_permutation_lat_trans_O4(
 
     if c_pt is not None:
         proj_pt += dot_product_sparse(c_pt.T, c_pt, use_mkl=use_mkl)
-
     return proj_pt
 
 

--- a/src/symfc/utils/utils_O2.py
+++ b/src/symfc/utils/utils_O2.py
@@ -292,32 +292,23 @@ def get_compr_coset_projector_O2(
     if fc_cutoff is None:
         nonzero = None
         size_data = N**2
+        col = atomic_decompr_idx
     else:
         nonzero = fc_cutoff.nonzero_atomic_indices_fc2()
         size_data = np.count_nonzero(nonzero)
+        col = atomic_decompr_idx[nonzero]
 
     factor = 1 / n_lp / len(spg_reps.unique_rotation_indices)
     for i, _ in enumerate(spg_reps.unique_rotation_indices):
         permutation = spg_reps.get_sigma2_rep(i, nonzero=nonzero)
-        if nonzero is None:
-            mat = csr_array(
-                (
-                    np.ones(size_data, dtype="int_"),
-                    (atomic_decompr_idx[permutation], atomic_decompr_idx),
-                ),
-                shape=(N**2 // n_lp, N**2 // n_lp),
-                dtype="int_",
-            )
-        else:
-            mat = csr_array(
-                (
-                    np.ones(size_data, dtype="int_"),
-                    (atomic_decompr_idx[permutation], atomic_decompr_idx[nonzero]),
-                ),
-                shape=(N**2 // n_lp, N**2 // n_lp),
-                dtype="int_",
-            )
-
+        mat = csr_array(
+            (
+                np.ones(size_data, dtype="int_"),
+                (atomic_decompr_idx[permutation], col),
+            ),
+            shape=(N**2 // n_lp, N**2 // n_lp),
+            dtype="int_",
+        )
         mat = kron(mat, spg_reps.r_reps[i] * factor)
         if c_pt is not None:
             mat = c_pt.T @ mat @ c_pt

--- a/src/symfc/utils/utils_O4.py
+++ b/src/symfc/utils/utils_O4.py
@@ -156,9 +156,11 @@ def get_compr_coset_projector_O4(
     if fc_cutoff is None:
         nonzero = None
         size_data = N**4
+        col = atomic_decompr_idx
     else:
         nonzero = fc_cutoff.nonzero_atomic_indices_fc4()
         size_data = np.count_nonzero(nonzero)
+        col = atomic_decompr_idx[nonzero]
 
     factor = 1 / n_lp / len(spg_reps.unique_rotation_indices)
     for i, _ in enumerate(spg_reps.unique_rotation_indices):
@@ -171,27 +173,17 @@ def get_compr_coset_projector_O4(
                 flush=True,
             )
         permutation = spg_reps.get_sigma4_rep(i, nonzero=nonzero)
-        if nonzero is None:
-            """Equivalent to mat = C.T @ spg_reps.get_sigma4_rep(i) @ C
-            C: atomic_lat_trans_compr_mat, shape=(NNNN, NNNN/n_lp)"""
-            mat = csr_array(
-                (
-                    np.ones(size_data, dtype="int_"),
-                    (atomic_decompr_idx[permutation], atomic_decompr_idx),
-                ),
-                shape=(N**4 // n_lp, N**4 // n_lp),
-                dtype="int_",
-            )
-        else:
-            mat = csr_array(
-                (
-                    np.ones(size_data, dtype="int_"),
-                    (atomic_decompr_idx[permutation], atomic_decompr_idx[nonzero]),
-                ),
-                shape=(N**4 // n_lp, N**4 // n_lp),
-                dtype="int_",
-            )
 
+        """Equivalent to mat = C.T @ spg_reps.get_sigma4_rep(i) @ C
+        C: atomic_lat_trans_compr_mat, shape=(NNNN, NNNN/n_lp)"""
+        mat = csr_array(
+            (
+                np.ones(size_data, dtype="int_"),
+                (atomic_decompr_idx[permutation], col),
+            ),
+            shape=(N**4 // n_lp, N**4 // n_lp),
+            dtype="int_",
+        )
         mat = kron(mat, spg_reps.r_reps[i] * factor)
         if c_pt is not None:
             mat = c_pt.T @ mat @ c_pt


### PR DESCRIPTION
Codes for calculating LT.T @ coset @ LT and perm.T @ LT are simplified to improve readability.