### PR TITLE
Develop a direct basis construction for permutation and lattice translation

### DIFF
--- a/src/symfc/basis_sets/basis_sets_O2.py
+++ b/src/symfc/basis_sets/basis_sets_O2.py
@@ -18,6 +18,7 @@ from symfc.utils.matrix_tools_O2 import (
     compressed_projector_sum_rules_O2,
     projector_permutation_lat_trans_O2,
 )
+from symfc.utils.permutation_tools_O2 import compr_permutation_lat_trans_O2
 from symfc.utils.rotation_tools_O2 import complementary_compr_projector_rot_sum_rules_O2
 from symfc.utils.utils import SymfcAtoms
 from symfc.utils.utils_O2 import (
@@ -132,15 +133,25 @@ class FCBasisSetO2(FCBasisSetBase):
     def run(self, rotational_sum_rules: bool = False) -> FCBasisSetO2:
         """Compute compressed force constants basis set."""
         trans_perms = self._spg_reps.translation_permutations
-        proj_pt = projector_permutation_lat_trans_O2(
-            trans_perms,
-            atomic_decompr_idx=self._atomic_decompr_idx,
-            fc_cutoff=self._fc_cutoff,
-            use_mkl=self._use_mkl,
-            verbose=self._log_level > 0,
-        )
 
-        c_pt = eigsh_projector(proj_pt, verbose=self._log_level > 0)
+        direct_permutation = True
+        if direct_permutation:
+            c_pt = compr_permutation_lat_trans_O2(
+                trans_perms,
+                atomic_decompr_idx=self._atomic_decompr_idx,
+                fc_cutoff=self._fc_cutoff,
+                verbose=self._log_level > 0,
+            )
+        else:
+            proj_pt = projector_permutation_lat_trans_O2(
+                trans_perms,
+                atomic_decompr_idx=self._atomic_decompr_idx,
+                fc_cutoff=self._fc_cutoff,
+                use_mkl=self._use_mkl,
+                verbose=self._log_level > 0,
+            )
+            c_pt = eigsh_projector(proj_pt, verbose=self._log_level > 0)
+
         proj_rpt = get_compr_coset_projector_O2(
             self._spg_reps,
             fc_cutoff=self._fc_cutoff,

--- a/src/symfc/basis_sets/basis_sets_O3.py
+++ b/src/symfc/basis_sets/basis_sets_O3.py
@@ -139,14 +139,9 @@ class FCBasisSetO3(FCBasisSetBase):
         """Compute compressed force constants basis set."""
         trans_perms = self._spg_reps.translation_permutations
 
-        if self._fc_cutoff is not None:
-            direct_permutation = False
-        else:
-            direct_permutation = True
-
+        direct_permutation = True
+        tt0 = time.time()
         if direct_permutation:
-            tt0 = time.time()
-            tt1 = time.time()
             c_pt = compr_permutation_lat_trans_O3(
                 trans_perms,
                 atomic_decompr_idx=self._atomic_decompr_idx,
@@ -154,7 +149,6 @@ class FCBasisSetO3(FCBasisSetBase):
                 verbose=self._log_level > 0,
             )
         else:
-            tt0 = time.time()
             proj_pt = projector_permutation_lat_trans_O3(
                 trans_perms,
                 atomic_decompr_idx=self._atomic_decompr_idx,
@@ -203,16 +197,24 @@ class FCBasisSetO3(FCBasisSetBase):
         tt7 = time.time()
 
         if self._log_level:
-            print(
-                "Time (proj(perm @ lattice trans.)  :",
-                "{:.3f}".format(tt1 - tt0),
-                flush=True,
-            )
-            print(
-                "Time (eigh(perm @ ltrans))         :",
-                "{:.3f}".format(tt2 - tt1),
-                flush=True,
-            )
+            if direct_permutation:
+                print(
+                    "Time (perm @ ltrans)               :",
+                    "{:.3f}".format(tt2 - tt0),
+                    flush=True,
+                )
+
+            else:
+                print(
+                    "Time (proj(perm @ lattice trans.)  :",
+                    "{:.3f}".format(tt1 - tt0),
+                    flush=True,
+                )
+                print(
+                    "Time (eigh(perm @ ltrans))         :",
+                    "{:.3f}".format(tt2 - tt1),
+                    flush=True,
+                )
             print(
                 "Time (coset)                       :",
                 "{:.3f}".format(tt3 - tt2),

--- a/src/symfc/utils/matrix_tools.py
+++ b/src/symfc/utils/matrix_tools.py
@@ -27,7 +27,12 @@ def get_entire_combinations(n, r):
     return combs.T
 
 
-def get_combinations(natom: int, order: int, fc_cutoff: Optional[FCCutoff] = None):
+def get_combinations(
+    natom: int,
+    order: int,
+    fc_cutoff: Optional[FCCutoff] = None,
+    indep_atoms: Optional[np.ndarray] = None,
+):
     """Return numpy array of FC index combinations."""
     if fc_cutoff is None:
         combinations = get_entire_combinations(3 * natom, order)
@@ -43,6 +48,13 @@ def get_combinations(natom: int, order: int, fc_cutoff: Optional[FCCutoff] = Non
             raise NotImplementedError(
                 "Combinations are implemented only for 2 <= order <= 4."
             )
+
+    if indep_atoms is not None:
+        nonzero = np.zeros(combinations.shape[0], dtype=bool)
+        atom_indices = combinations[:, 0] // 3
+        for i in indep_atoms:
+            nonzero[atom_indices == i] = True
+        combinations = combinations[nonzero]
     return combinations
 
 

--- a/src/symfc/utils/permutation_tools.py
+++ b/src/symfc/utils/permutation_tools.py
@@ -1,0 +1,35 @@
+"""Permutation utility functions."""
+
+import numpy as np
+import scipy
+from scipy.sparse import csr_array
+
+
+def construct_basis_from_orbits(orbits: np.ndarray):
+    """Transform orbits into basis matrix."""
+    size_full = len(orbits)
+    nonzero = orbits != -1
+    if not np.all(nonzero):
+        orbits = orbits[nonzero]
+        nonzero_map = np.ones(size_full, dtype="int") * -1
+        nonzero_map[nonzero] = np.arange(len(orbits))
+        orbits = nonzero_map[orbits]
+
+    size1 = len(orbits)
+    orbits = csr_array(
+        (np.ones(size1, dtype=bool), (np.arange(size1), orbits)),
+        shape=(size1, size1),
+        dtype=bool,
+    )
+
+    n_col, cols = scipy.sparse.csgraph.connected_components(orbits)
+    key, cnt = np.unique(cols, return_counts=True)
+    values = np.reciprocal(np.sqrt(cnt))
+
+    rows = np.where(nonzero)[0]
+    c_pt = csr_array(
+        (values[cols], (rows, cols)),
+        shape=(size_full, n_col),
+        dtype="double",
+    )
+    return c_pt

--- a/src/symfc/utils/permutation_tools_O2.py
+++ b/src/symfc/utils/permutation_tools_O2.py
@@ -10,24 +10,21 @@ from symfc.utils.matrix_tools import get_combinations
 from symfc.utils.permutation_tools import construct_basis_from_orbits
 from symfc.utils.solver_funcs import get_batch_slice
 from symfc.utils.utils import get_indep_atoms_by_lat_trans
-from symfc.utils.utils_O3 import get_atomic_lat_trans_decompr_indices_O3
+from symfc.utils.utils_O2 import _get_atomic_lat_trans_decompr_indices
 
 
-def _N3N3N3_to_NNNand333(combs: np.ndarray, N: int) -> np.ndarray:
+def _N3N3_to_NNand33(combs: np.ndarray, N: int) -> np.ndarray:
     """Transform index order."""
-    vecNNN, vec333 = np.divmod(combs[:, 0], 3)
-    vecNNN *= N**2
-    vec333 *= 9
+    vecNN, vec33 = np.divmod(combs[:, 0], 3)
+    vecNN *= N
+    vec33 *= 3
     div, mod = np.divmod(combs[:, 1], 3)
-    vecNNN += div * N
-    vec333 += mod * 3
-    div, mod = np.divmod(combs[:, 2], 3)
-    vecNNN += div
-    vec333 += mod
-    return vecNNN, vec333
+    vecNN += div
+    vec33 += mod
+    return vecNN, vec33
 
 
-def compr_permutation_lat_trans_O3(
+def compr_permutation_lat_trans_O2(
     trans_perms: np.ndarray,
     atomic_decompr_idx: Optional[np.ndarray] = None,
     fc_cutoff: Optional[FCCutoff] = None,
@@ -54,19 +51,16 @@ def compr_permutation_lat_trans_O3(
     C_pt = eigh(C_trans.T @ C_perm @ C_perm.T @ C_trans)
     """
     n_lp, natom = trans_perms.shape
-    NNN27 = natom**3 * 27
+    NN9 = natom**2 * 9
     if atomic_decompr_idx is None:
-        atomic_decompr_idx = get_atomic_lat_trans_decompr_indices_O3(trans_perms)
+        atomic_decompr_idx = _get_atomic_lat_trans_decompr_indices(trans_perms)
 
-    if n_batch is None:
-        n_batch = 1 if natom <= 128 else int(round((natom / 128) ** 2))
-
-    orbits = np.ones(NNN27 // n_lp, dtype="int") * -1
+    orbits = np.ones(NN9 // n_lp, dtype="int") * -1
     indep_atoms = get_indep_atoms_by_lat_trans(trans_perms)
 
     # order = 1
-    combinations = np.array([[i, i, i] for i in range(3 * natom)], dtype=int)
-    perms = [[0, 0, 0]]
+    combinations = np.array([[i, i] for i in range(3 * natom)], dtype=int)
+    perms = [[0, 0]]
     orbits = _update_orbits_from_combinations(
         combinations,
         perms,
@@ -82,37 +76,7 @@ def compr_permutation_lat_trans_O3(
     combinations = get_combinations(
         natom, order=2, fc_cutoff=fc_cutoff, indep_atoms=indep_atoms
     )
-    perms = [
-        [0, 0, 1],
-        [0, 1, 0],
-        [1, 0, 0],
-        [0, 1, 1],
-        [1, 0, 1],
-        [1, 1, 0],
-    ]
-    orbits = _update_orbits_from_combinations(
-        combinations,
-        perms,
-        atomic_decompr_idx,
-        trans_perms,
-        orbits,
-        n_perms_group=2,
-        n_batch=1,
-        verbose=verbose,
-    )
-
-    # order = 3
-    combinations = get_combinations(
-        natom, order=3, fc_cutoff=fc_cutoff, indep_atoms=indep_atoms
-    )
-    perms = [
-        [0, 1, 2],
-        [0, 2, 1],
-        [1, 0, 2],
-        [1, 2, 0],
-        [2, 0, 1],
-        [2, 1, 0],
-    ]
+    perms = [[0, 1], [1, 0]]
     orbits = _update_orbits_from_combinations(
         combinations,
         perms,
@@ -120,10 +84,9 @@ def compr_permutation_lat_trans_O3(
         trans_perms,
         orbits,
         n_perms_group=1,
-        n_batch=n_batch,
+        n_batch=1,
         verbose=verbose,
     )
-
     if verbose:
         print("Construct basis matrix for permutations", flush=True)
     c_pt = construct_basis_from_orbits(orbits)
@@ -148,9 +111,9 @@ def _update_orbits_from_combinations(
     for begin, end in zip(*get_batch_slice(n_comb, n_comb // n_batch)):
         if verbose:
             print("Permutation basis:", str(end) + "/" + str(n_comb), flush=True)
-        combs_perm = combinations[begin:end][:, permutations].reshape((-1, 3))
-        combs_perm, combs333 = _N3N3N3_to_NNNand333(combs_perm, natom)
-        cols = atomic_decompr_idx[combs_perm] * 27 + combs333
+        combs_perm = combinations[begin:end][:, permutations].reshape((-1, 2))
+        combs_perm, combs33 = _N3N3_to_NNand33(combs_perm, natom)
+        cols = atomic_decompr_idx[combs_perm] * 9 + combs33
         cols = cols.reshape(-1, n_perms_sym)
         for c in cols.T:
             orbits[c] = cols[:, 0]

--- a/src/symfc/utils/permutation_tools_O3.py
+++ b/src/symfc/utils/permutation_tools_O3.py
@@ -79,14 +79,9 @@ def compr_permutation_lat_trans_O3(
     )
 
     # order = 2
-    combinations = get_combinations(natom, order=2, fc_cutoff=fc_cutoff)
-
-    nonzero = np.zeros(combinations.shape[0], dtype=bool)
-    atom_indices = combinations[:, 0] // 3
-    for i in indep_atoms:
-        nonzero[atom_indices == i] = True
-    combinations = combinations[nonzero]
-
+    combinations = get_combinations(
+        natom, order=2, fc_cutoff=fc_cutoff, indep_atoms=indep_atoms
+    )
     perms = [
         [0, 0, 1],
         [0, 1, 0],
@@ -107,14 +102,9 @@ def compr_permutation_lat_trans_O3(
     )
 
     # order = 3
-    combinations = get_combinations(natom, order=3, fc_cutoff=fc_cutoff)
-
-    nonzero = np.zeros(combinations.shape[0], dtype=bool)
-    atom_indices = combinations[:, 0] // 3
-    for i in indep_atoms:
-        nonzero[atom_indices == i] = True
-    combinations = combinations[nonzero]
-
+    combinations = get_combinations(
+        natom, order=3, fc_cutoff=fc_cutoff, indep_atoms=indep_atoms
+    )
     perms = [
         [0, 1, 2],
         [0, 2, 1],
@@ -154,20 +144,16 @@ def _update_orbits_from_combinations(
     n_lp, natom = trans_perms.shape
     n_comb = combinations.shape[0]
     n_perms = len(permutations)
-
     n_perms_sym = n_perms // n_perms_group
     for begin, end in zip(*get_batch_slice(n_comb, n_comb // n_batch)):
         if verbose:
             print("Permutation basis:", str(end) + "/" + str(n_comb), flush=True)
         combs_perm = combinations[begin:end][:, permutations].reshape((-1, 3))
         combs_perm, combs333 = _N3N3N3_to_NNNand333(combs_perm, natom)
-
         cols = atomic_decompr_idx[combs_perm] * 27 + combs333
-        rep_col = np.tile(
-            np.min(cols.reshape((-1, n_perms_sym)), axis=1), (n_perms_sym, 1)
-        ).T.reshape(-1)
-
-        orbits[cols] = rep_col
+        cols = cols.reshape(-1, n_perms_sym)
+        for c in cols.T:
+            orbits[c] = cols[:, 0]
     return orbits
 
 


### PR DESCRIPTION
A procedure for directly constructing a basis set for permutation and lattice translation has been implemented. This is now applicable to FC2 and FC3, taking cutoff distances into account.