### PR TITLE
Add setter of basis_set to Symfc class

### DIFF
--- a/src/symfc/api_symfc.py
+++ b/src/symfc/api_symfc.py
@@ -77,15 +77,17 @@ class Symfc:
 
     @property
     def basis_set(self) -> dict[FCBasisSetBase]:
-        """Return basis set instance.
+        """Setter and getter of basis set.
 
-        Returns
-        -------
         dict[FCBasisSet]
             The key is the order of basis set in int.
 
         """
         return self._basis_set
+
+    @basis_set.setter
+    def basis_set(self, basis_set):
+        self._basis_set = basis_set
 
     @property
     def force_constants(self) -> dict[np.ndarray]:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -31,7 +31,14 @@ def test_api_NaCl_222(ph_nacl_222: tuple[SymfcAtoms, np.ndarray, np.ndarray]):
 def test_api_NaCl_222_with_dataset(
     ph_nacl_222: tuple[SymfcAtoms, np.ndarray, np.ndarray],
 ):
-    """Test Symfc class with displacements and forces as input."""
+    """Test Symfc class with displacements and forces as input.
+
+    1. symfc.run()
+    2. basis_set = symfc.basis_set.
+    3. new_symfc.basis_set
+    4. new_symfc.solve()
+
+    """
     supercell, displacements, forces = ph_nacl_222
     symfc = Symfc(
         supercell,
@@ -41,6 +48,15 @@ def test_api_NaCl_222_with_dataset(
     fc = symfc.force_constants[2]
     fc_ref = np.loadtxt(cwd / "compact_fc_NaCl_222.xz").reshape(fc.shape)
     np.testing.assert_allclose(fc, fc_ref)
+
+    new_symfc = Symfc(
+        supercell,
+        displacements=displacements,
+        forces=forces,
+    )
+    new_symfc.basis_set = symfc.basis_set
+    new_symfc.solve(max_order=2)
+    np.testing.assert_allclose(new_symfc.force_constants[2], fc_ref)
 
 
 def test_api_NaCl_222_exception(ph_nacl_222: tuple[SymfcAtoms, np.ndarray, np.ndarray]):


### PR DESCRIPTION
The aim is to reuse an existing Symfc instance without running `compute_basis_set` again but with different learning data.