### PR TITLE
Minor change of Symfc.estimate_basis_set

### DIFF
--- a/src/symfc/api_symfc.py
+++ b/src/symfc/api_symfc.py
@@ -68,6 +68,11 @@ class Symfc:
         self._prepare_cutoff(cutoff)
 
     @property
+    def supercell(self) -> SymfcAtoms:
+        """Return supercell."""
+        return self._supercell
+
+    @property
     def p2s_map(self) -> Optional[np.ndarray]:
         """Return indices of translationally independent atoms."""
         if self._basis_set:

--- a/src/symfc/api_symfc.py
+++ b/src/symfc/api_symfc.py
@@ -276,8 +276,7 @@ class Symfc:
         orders: list
             Orders of force constants.
         """
-        orders = self._check_orders(max_order, orders)
-        for order in orders:
+        for order in self._check_orders(max_order, orders):
             if order == 2:
                 basis_set_o2 = FCBasisSetO2(
                     self._supercell,
@@ -306,46 +305,56 @@ class Symfc:
                 self._basis_set[4] = basis_set_o4
         return self
 
-    def estimate_basis_size(self, order: Optional[int] = None):
+    def estimate_basis_size(
+        self,
+        max_order: Optional[int] = None,
+        orders: Optional[list] = None,
+    ) -> dict:
         """Estimate the size of basis set.
 
         Parameters
         ----------
-        order : int
-            FC order.
+        max_order : int
+            Maximum fc order.
+        orders: list
+            Orders of force constants.
 
         Returns
         -------
-        basis_size_estimates: Estimates of basis set size.
+        dict :
+            Estimates of basis set sizes for each order. The key of dict is the
+            order.
         """
-        if order < 2 or order > 4:
-            raise NotImplementedError(
-                "Only fc2, fc3 and fc4 basis sets are implemented."
-            )
+        basis_size_estimates = {}
+        for order in self._check_orders(max_order, orders):
+            if order < 2 or order > 4:
+                raise NotImplementedError(
+                    "Only fc2, fc3 and fc4 basis sets are implemented."
+                )
 
-        if order == 2:
-            basis_size_estimates = FCBasisSetO2(
-                self._supercell,
-                spacegroup_operations=self._spacegroup_operations,
-                use_mkl=self._use_mkl,
-                log_level=self._log_level,
-            ).estimate_basis_size()
-        elif order == 3:
-            basis_size_estimates = FCBasisSetO3(
-                self._supercell,
-                spacegroup_operations=self._spacegroup_operations,
-                cutoff=self._cutoff[3],
-                use_mkl=self._use_mkl,
-                log_level=self._log_level,
-            ).estimate_basis_size()
-        elif order == 4:
-            basis_size_estimates = FCBasisSetO4(
-                self._supercell,
-                spacegroup_operations=self._spacegroup_operations,
-                cutoff=self._cutoff[4],
-                use_mkl=self._use_mkl,
-                log_level=self._log_level,
-            ).estimate_basis_size()
+            if order == 2:
+                basis_size_estimates[order] = FCBasisSetO2(
+                    self._supercell,
+                    spacegroup_operations=self._spacegroup_operations,
+                    use_mkl=self._use_mkl,
+                    log_level=self._log_level,
+                ).estimate_basis_size()
+            elif order == 3:
+                basis_size_estimates[order] = FCBasisSetO3(
+                    self._supercell,
+                    spacegroup_operations=self._spacegroup_operations,
+                    cutoff=self._cutoff[3],
+                    use_mkl=self._use_mkl,
+                    log_level=self._log_level,
+                ).estimate_basis_size()
+            elif order == 4:
+                basis_size_estimates[order] = FCBasisSetO4(
+                    self._supercell,
+                    spacegroup_operations=self._spacegroup_operations,
+                    cutoff=self._cutoff[4],
+                    use_mkl=self._use_mkl,
+                    log_level=self._log_level,
+                ).estimate_basis_size()
 
         return basis_size_estimates
 

--- a/src/symfc/basis_sets/basis_sets_O2.py
+++ b/src/symfc/basis_sets/basis_sets_O2.py
@@ -192,7 +192,7 @@ class FCBasisSetO2(FCBasisSetBase):
         if self._fc_cutoff is None:
             n_sym, N = self._spg_reps._permutations.shape
             basis_size_estimates = 9 * (N**2) / n_sym / 2
-            return np.round(basis_size_estimates).astype(int)
+            return int(np.round(basis_size_estimates).astype(int))
 
         trans_perms = self._spg_reps.translation_permutations
         c_pt = compr_permutation_lat_trans_O2(
@@ -203,4 +203,4 @@ class FCBasisSetO2(FCBasisSetBase):
         )
         n_sym_prim = len(self._spg_reps._unique_rotations)
         basis_size_estimates = c_pt.shape[1] / n_sym_prim
-        return np.round(basis_size_estimates).astype(int)
+        return int(np.round(basis_size_estimates).astype(int))

--- a/src/symfc/basis_sets/basis_sets_O3.py
+++ b/src/symfc/basis_sets/basis_sets_O3.py
@@ -256,7 +256,7 @@ class FCBasisSetO3(FCBasisSetBase):
         if self._fc_cutoff is None:
             n_sym, N = self._spg_reps._permutations.shape
             basis_size_estimates = 27 * (N**3) / n_sym / 6
-            return np.round(basis_size_estimates).astype(int)
+            return int(np.round(basis_size_estimates).astype(int))
 
         trans_perms = self._spg_reps.translation_permutations
         c_pt = compr_permutation_lat_trans_O3(
@@ -267,4 +267,4 @@ class FCBasisSetO3(FCBasisSetBase):
         )
         n_sym_prim = len(self._spg_reps._unique_rotations)
         basis_size_estimates = c_pt.shape[1] / n_sym_prim
-        return np.round(basis_size_estimates).astype(int)
+        return int(np.round(basis_size_estimates).astype(int))

--- a/src/symfc/basis_sets/basis_sets_O4.py
+++ b/src/symfc/basis_sets/basis_sets_O4.py
@@ -251,7 +251,7 @@ class FCBasisSetO4(FCBasisSetBase):
         if self._fc_cutoff is None:
             n_sym, N = self._spg_reps._permutations.shape
             basis_size_estimates = 81 * (N**4) / n_sym / 24
-            return np.round(basis_size_estimates).astype(int)
+            return int(np.round(basis_size_estimates).astype(int))
 
         trans_perms = self._spg_reps.translation_permutations
         c_pt = compr_permutation_lat_trans_O4(
@@ -262,4 +262,4 @@ class FCBasisSetO4(FCBasisSetBase):
         )
         n_sym_prim = len(self._spg_reps._unique_rotations)
         basis_size_estimates = c_pt.shape[1] / n_sym_prim
-        return np.round(basis_size_estimates).astype(int)
+        return int(np.round(basis_size_estimates).astype(int))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,8 +78,8 @@ def cell_gan_111() -> SymfcAtoms:
 
 
 @pytest.fixture(scope="session")
-def ph_nacl_222() -> tuple[SymfcAtoms, np.ndarray, np.ndarray]:
-    """Return NaCl-222 data."""
+def cell_nacl_222() -> SymfcAtoms:
+    """Return 2x2x2 supercell of NaCl."""
     lattice = [
         [11.281120000000000, 0.000000000000000, 0.000000000000000],
         [0.000000000000000, 11.281120000000000, 0.000000000000000],
@@ -218,11 +218,17 @@ def ph_nacl_222() -> tuple[SymfcAtoms, np.ndarray, np.ndarray]:
         17,
     ]
     cell = SymfcAtoms(cell=lattice, scaled_positions=points, numbers=numbers)
+    return cell
+
+
+@pytest.fixture(scope="session")
+def ph_nacl_222(cell_nacl_222) -> tuple[SymfcAtoms, np.ndarray, np.ndarray]:
+    """Return NaCl-222 data."""
     N = 20
     dfset = np.loadtxt(cwd / "dfset_NaCl_222_rd.xz")
     d = dfset[:, :3].reshape(N, -1, 3)
     f = dfset[:, 3:].reshape(N, -1, 3)
-    return cell, d, f
+    return cell_nacl_222, d, f
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -166,3 +166,18 @@ def test_api_si_111_fc4_step(
     np.testing.assert_allclose(fc2_ref, fc2, atol=1e-6)
     np.testing.assert_allclose(fc3_ref, fc3, atol=1e-6)
     np.testing.assert_allclose(fc4_ref, fc4, atol=1e-6)
+
+
+def test_api_estimate_basis_size_NaCl_222(
+    cell_nacl_222: SymfcAtoms,
+):
+    """Test Symfc class."""
+    symfc = Symfc(cell_nacl_222)
+    ref_estimates = {
+        2: 12,
+        3: 768,
+        4: 36864,
+    }
+
+    assert symfc.estimate_basis_size(orders=[2, 3, 4]) == ref_estimates
+    assert symfc.estimate_basis_size(max_order=4) == ref_estimates


### PR DESCRIPTION
Changed `Symfc.estimate_basis_set` returns dict with keys as orders.
Added a regression test.
Added `Symfc.supercell` attribute because it is convenient to know the number of atoms to estimate minimum number of supercells necessary for solving force constants.