### PR TITLE
Update docstrings and variables

### DIFF
--- a/src/symfc/utils/eig_tools.py
+++ b/src/symfc/utils/eig_tools.py
@@ -359,10 +359,23 @@ def eigsh_projector_sumrule_large(p: csr_array, verbose: bool = True) -> np.ndar
     When p = diag(A,B), Av = v, and Bw = w, p[v,0] = [v,0] and p[0,w] = [0,w]
     are solutions.
 
-    This function solves numpy.eigh for all block matrices.
-    This function is efficient for matrix p composed of nonequivalent
-    block matrices.
-
+    This algorithm is optimized to solve an eigenvalue problem for
+    projection matrix p with large block submatrices.
+    The algorithm for solving each block submatrix is as follows.
+    1. Divide each block submatrix into reasonable sizes of submatrices,
+       not projectors.
+    2. Solve eigenvalue problems for these submatrices and eigenvectors
+       with eigenvalues of one are extracted. The eigenvectors with
+       eigenvalues e < 1 are used for compressing the complementary matrix
+       in the next step.
+    3. Calculate the complementary matrix, which corresponds to the complement
+       of the vector space spanned by the eigenvectors. The complementary matrix
+       is compressed using the eigenvectors with e < 1.
+    4. Solve eigenvalue problem for the complementary matrix and eigenvectors
+       with e = 1 are calculated. The eigenvalue problems are efficiently solved
+       using the compressed complementary matrix and the eigenvectors are recovered by
+       the compression matrix.
+    5. Collect all eigenvectors with e = 1.
     """
     group = _find_projector_blocks(p)
     if verbose:

--- a/src/symfc/utils/matrix_tools.py
+++ b/src/symfc/utils/matrix_tools.py
@@ -1,61 +1,7 @@
 """Matrix utility functions."""
 
-from typing import Optional
-
 import numpy as np
 from scipy.sparse import csr_array
-
-from symfc.utils.cutoff_tools import FCCutoff
-
-
-def get_entire_combinations(n, r):
-    """Return numpy array of combinations.
-
-    combinations = np.array(
-       list(itertools.combinations(range(n), r)), dtype=int
-    )
-    """
-    combs = np.ones((r, n - r + 1), dtype=int)
-    combs[0] = np.arange(n - r + 1)
-    for j in range(1, r):
-        reps = (n - r + j) - combs[j - 1]
-        combs = np.repeat(combs, reps, axis=1)
-        ind = np.add.accumulate(reps)
-        combs[j, ind[:-1]] = 1 - reps[1:]
-        combs[j, 0] = j
-        combs[j] = np.add.accumulate(combs[j])
-    return combs.T
-
-
-def get_combinations(
-    natom: int,
-    order: int,
-    fc_cutoff: Optional[FCCutoff] = None,
-    indep_atoms: Optional[np.ndarray] = None,
-):
-    """Return numpy array of FC index combinations."""
-    if fc_cutoff is None:
-        combinations = get_entire_combinations(3 * natom, order)
-    else:
-        if order == 2:
-            combinations = fc_cutoff.combinations2()
-        elif order == 3:
-            """Combinations can be divided using fc_cut.combiations3(i)."""
-            combinations = fc_cutoff.combinations3_all()
-        elif order == 4:
-            combinations = fc_cutoff.combinations4_all()
-        else:
-            raise NotImplementedError(
-                "Combinations are implemented only for 2 <= order <= 4."
-            )
-
-    if indep_atoms is not None:
-        nonzero = np.zeros(combinations.shape[0], dtype=bool)
-        atom_indices = combinations[:, 0] // 3
-        for i in indep_atoms:
-            nonzero[atom_indices == i] = True
-        combinations = combinations[nonzero]
-    return combinations
 
 
 def permutation_dot_lat_trans(

--- a/src/symfc/utils/matrix_tools_O2.py
+++ b/src/symfc/utils/matrix_tools_O2.py
@@ -7,7 +7,8 @@ import scipy
 from scipy.sparse import csr_array
 
 from symfc.utils.cutoff_tools import FCCutoff
-from symfc.utils.matrix_tools import get_combinations, permutation_dot_lat_trans
+from symfc.utils.matrix_tools import permutation_dot_lat_trans
+from symfc.utils.permutation_tools import get_combinations
 from symfc.utils.solver_funcs import get_batch_slice
 from symfc.utils.utils import get_indep_atoms_by_lat_trans
 from symfc.utils.utils_O2 import _get_atomic_lat_trans_decompr_indices

--- a/src/symfc/utils/matrix_tools_O3.py
+++ b/src/symfc/utils/matrix_tools_O3.py
@@ -7,7 +7,8 @@ import scipy
 from scipy.sparse import csr_array, vstack
 
 from symfc.utils.cutoff_tools import FCCutoff
-from symfc.utils.matrix_tools import get_combinations, permutation_dot_lat_trans
+from symfc.utils.matrix_tools import permutation_dot_lat_trans
+from symfc.utils.permutation_tools import get_combinations
 from symfc.utils.solver_funcs import get_batch_slice
 from symfc.utils.utils import get_indep_atoms_by_lat_trans
 from symfc.utils.utils_O3 import get_atomic_lat_trans_decompr_indices_O3

--- a/src/symfc/utils/matrix_tools_O4.py
+++ b/src/symfc/utils/matrix_tools_O4.py
@@ -8,7 +8,8 @@ import scipy
 from scipy.sparse import csr_array, vstack
 
 from symfc.utils.cutoff_tools import FCCutoff
-from symfc.utils.matrix_tools import get_combinations, permutation_dot_lat_trans
+from symfc.utils.matrix_tools import permutation_dot_lat_trans
+from symfc.utils.permutation_tools import get_combinations
 from symfc.utils.solver_funcs import get_batch_slice
 from symfc.utils.utils import get_indep_atoms_by_lat_trans
 from symfc.utils.utils_O4 import get_atomic_lat_trans_decompr_indices_O4

--- a/src/symfc/utils/permutation_tools.py
+++ b/src/symfc/utils/permutation_tools.py
@@ -1,28 +1,106 @@
 """Permutation utility functions."""
 
+from typing import Optional
+
 import numpy as np
 import scipy
 from scipy.sparse import csr_array
 
+from symfc.utils.cutoff_tools import FCCutoff
 
-def construct_basis_from_orbits(orbits: np.ndarray):
-    """Transform orbits into basis matrix."""
-    size_full = len(orbits)
-    nonzero = orbits != -1
+
+def get_entire_combinations(n: int, r: int):
+    """Return numpy array of combinations.
+
+    combinations = np.array(
+       list(itertools.combinations(range(n), r)), dtype=int
+    )
+    """
+    combs = np.ones((r, n - r + 1), dtype=int)
+    combs[0] = np.arange(n - r + 1)
+    for j in range(1, r):
+        reps = (n - r + j) - combs[j - 1]
+        combs = np.repeat(combs, reps, axis=1)
+        ind = np.add.accumulate(reps)
+        combs[j, ind[:-1]] = 1 - reps[1:]
+        combs[j, 0] = j
+        combs[j] = np.add.accumulate(combs[j])
+    return combs.T
+
+
+def get_combinations(
+    natom: int,
+    order: int,
+    fc_cutoff: Optional[FCCutoff] = None,
+    indep_atoms: Optional[np.ndarray] = None,
+):
+    """Return numpy array of FC index combinations."""
+    if fc_cutoff is None:
+        combinations = get_entire_combinations(3 * natom, order)
+    else:
+        if order == 2:
+            combinations = fc_cutoff.combinations2()
+        elif order == 3:
+            """Combinations can be divided using fc_cut.combiations3(i)."""
+            combinations = fc_cutoff.combinations3_all()
+        elif order == 4:
+            combinations = fc_cutoff.combinations4_all()
+        else:
+            raise NotImplementedError(
+                "Combinations are implemented only for 2 <= order <= 4."
+            )
+
+    if indep_atoms is not None:
+        nonzero = np.zeros(combinations.shape[0], dtype=bool)
+        atom_indices = combinations[:, 0] // 3
+        for i in indep_atoms:
+            nonzero[atom_indices == i] = True
+        combinations = combinations[nonzero]
+    return combinations
+
+
+def _eliminate_zero_elements(
+    perm_decompr_idx: np.ndarray, nonzero: np.array
+) -> np.ndarray:
+    """Eliminate zero elements and reindex orbit indexes."""
+    size_full = len(perm_decompr_idx)
     if not np.all(nonzero):
-        orbits = orbits[nonzero]
+        perm_decompr_idx = perm_decompr_idx[nonzero]
         nonzero_map = np.ones(size_full, dtype="int") * -1
-        nonzero_map[nonzero] = np.arange(len(orbits))
-        orbits = nonzero_map[orbits]
+        nonzero_map[nonzero] = np.arange(len(perm_decompr_idx))
+        perm_decompr_idx = nonzero_map[perm_decompr_idx]
+    return perm_decompr_idx
 
-    size1 = len(orbits)
-    orbits = csr_array(
-        (np.ones(size1, dtype=bool), (np.arange(size1), orbits)),
+
+def construct_basis_from_perm_decompr_indices(
+    perm_decompr_idx: np.ndarray, verbose: bool = False
+):
+    """Transform perm_decompr_idx into basis matrix.
+
+    Parameters
+    ----------
+    perm_decompr_idx: Decompression indices of lattice translation basis
+                      using permutations.
+    Return
+    ------
+    c_pt: Compressed basis matrix for permutations and lattice translations.
+          c_pt = eigh(C_trans.T @ C_perm @ C_perm.T @ C_trans)
+    """
+    if verbose:
+        print("Construct permutation basis matrix.", flush=True)
+
+    size_full = len(perm_decompr_idx)
+    nonzero = perm_decompr_idx != -1
+    perm_decompr_idx = _eliminate_zero_elements(perm_decompr_idx, nonzero)
+
+    size1 = len(perm_decompr_idx)
+    perm_lat_trans_graph = csr_array(
+        (np.ones(size1, dtype=bool), (np.arange(size1), perm_decompr_idx)),
         shape=(size1, size1),
         dtype=bool,
     )
 
-    n_col, cols = scipy.sparse.csgraph.connected_components(orbits)
+    n_col, cols = scipy.sparse.csgraph.connected_components(perm_lat_trans_graph)
     key, cnt = np.unique(cols, return_counts=True)
     values = np.reciprocal(np.sqrt(cnt))
 

--- a/src/symfc/utils/permutation_tools_O2.py
+++ b/src/symfc/utils/permutation_tools_O2.py
@@ -6,8 +6,10 @@ import numpy as np
 from scipy.sparse import csr_array
 
 from symfc.utils.cutoff_tools import FCCutoff
-from symfc.utils.matrix_tools import get_combinations
-from symfc.utils.permutation_tools import construct_basis_from_orbits
+from symfc.utils.permutation_tools import (
+    construct_basis_from_perm_decompr_indices,
+    get_combinations,
+)
 from symfc.utils.solver_funcs import get_batch_slice
 from symfc.utils.utils import get_indep_atoms_by_lat_trans
 from symfc.utils.utils_O2 import _get_atomic_lat_trans_decompr_indices
@@ -31,7 +33,7 @@ def compr_permutation_lat_trans_O2(
     n_batch: Optional[int] = None,
     verbose: bool = False,
 ) -> csr_array:
-    """Build a compression matrix for permutation rules compressed by C_trans.
+    r"""Build a compression matrix for permutation rules compressed by C_trans.
 
     This calculates C_(trans,perm) without allocating C_trans and C_perm.
     Batch calculations are used to reduce memory allocation.
@@ -47,26 +49,38 @@ def compr_permutation_lat_trans_O2(
 
     Return
     ------
-    Compressed basis matrix for permutation
-    C_pt = eigh(C_trans.T @ C_perm @ C_perm.T @ C_trans)
+    c_pt: Compressed basis matrix for permutations and lattice translations.
+          c_pt = eigh(C_trans.T @ C_perm @ C_perm.T @ C_trans)
+          shape: (NN33//n_lp, n_basis_pt).
+          n_basis_pt denotes the size of basis for permutations and
+          lattice translations.
+
+    Algorithm
+    ---------
+    1. Calculate combinations {(i, a), (j, b)}.
+    2. Apply permutations to these combinations and calculate the orbits of
+       {(i, a), (j, b)} related to each other by permutations.
+    3. Calculate the lattice translation basis indices of the orbits,
+       and represent the lattice translation indices related to each other
+       by a representative in perm_decompr_idx.
     """
     n_lp, natom = trans_perms.shape
     NN9 = natom**2 * 9
     if atomic_decompr_idx is None:
         atomic_decompr_idx = _get_atomic_lat_trans_decompr_indices(trans_perms)
 
-    orbits = np.ones(NN9 // n_lp, dtype="int") * -1
+    perm_decompr_idx = np.ones(NN9 // n_lp, dtype="int") * -1
     indep_atoms = get_indep_atoms_by_lat_trans(trans_perms)
 
     # order = 1
     combinations = np.array([[i, i] for i in range(3 * natom)], dtype=int)
     perms = [[0, 0]]
-    orbits = _update_orbits_from_combinations(
+    perm_decompr_idx = _update_perm_decompr_indices(
         combinations,
         perms,
         atomic_decompr_idx,
         trans_perms,
-        orbits,
+        perm_decompr_idx,
         n_perms_group=1,
         n_batch=1,
         verbose=verbose,
@@ -77,33 +91,37 @@ def compr_permutation_lat_trans_O2(
         natom, order=2, fc_cutoff=fc_cutoff, indep_atoms=indep_atoms
     )
     perms = [[0, 1], [1, 0]]
-    orbits = _update_orbits_from_combinations(
+    perm_decompr_idx = _update_perm_decompr_indices(
         combinations,
         perms,
         atomic_decompr_idx,
         trans_perms,
-        orbits,
+        perm_decompr_idx,
         n_perms_group=1,
         n_batch=1,
         verbose=verbose,
     )
-    if verbose:
-        print("Construct basis matrix for permutations", flush=True)
-    c_pt = construct_basis_from_orbits(orbits)
+    c_pt = construct_basis_from_perm_decompr_indices(perm_decompr_idx, verbose=verbose)
     return c_pt
 
 
-def _update_orbits_from_combinations(
+def _update_perm_decompr_indices(
     combinations: np.ndarray,
     permutations: np.ndarray,
     atomic_decompr_idx: np.ndarray,
     trans_perms: np.ndarray,
-    orbits: np.ndarray,
+    perm_decompr_idx: np.ndarray,
     n_perms_group: int = 1,
     n_batch: int = 1,
     verbose: bool = False,
 ) -> csr_array:
-    """Construct projector of permutation and lattice translation."""
+    """Apply permutations to lattice translation basis.
+
+    Return
+    ------
+    perm_decompr_idx: Updated decompression indices of lattice translation basis
+                      using permutations.
+    """
     n_lp, natom = trans_perms.shape
     n_comb = combinations.shape[0]
     n_perms = len(permutations)
@@ -113,8 +131,8 @@ def _update_orbits_from_combinations(
             print("Permutation basis:", str(end) + "/" + str(n_comb), flush=True)
         combs_perm = combinations[begin:end][:, permutations].reshape((-1, 2))
         combs_perm, combs33 = _N3N3_to_NNand33(combs_perm, natom)
-        cols = atomic_decompr_idx[combs_perm] * 9 + combs33
-        cols = cols.reshape(-1, n_perms_sym)
-        for c in cols.T:
-            orbits[c] = cols[:, 0]
-    return orbits
+        decompr_idx_combs_perm = atomic_decompr_idx[combs_perm] * 9 + combs33
+        decompr_idx_combs_perm = decompr_idx_combs_perm.reshape(-1, n_perms_sym)
+        for orbit_components in decompr_idx_combs_perm.T:
+            perm_decompr_idx[orbit_components] = decompr_idx_combs_perm[:, 0]
+    return perm_decompr_idx

--- a/src/symfc/utils/permutation_tools_O3.py
+++ b/src/symfc/utils/permutation_tools_O3.py
@@ -6,8 +6,10 @@ import numpy as np
 from scipy.sparse import csr_array
 
 from symfc.utils.cutoff_tools import FCCutoff
-from symfc.utils.matrix_tools import get_combinations
-from symfc.utils.permutation_tools import construct_basis_from_orbits
+from symfc.utils.permutation_tools import (
+    construct_basis_from_perm_decompr_indices,
+    get_combinations,
+)
 from symfc.utils.solver_funcs import get_batch_slice
 from symfc.utils.utils import get_indep_atoms_by_lat_trans
 from symfc.utils.utils_O3 import get_atomic_lat_trans_decompr_indices_O3
@@ -34,7 +36,7 @@ def compr_permutation_lat_trans_O3(
     n_batch: Optional[int] = None,
     verbose: bool = False,
 ) -> csr_array:
-    """Build a compression matrix for permutation rules compressed by C_trans.
+    r"""Build a compression matrix for permutation rules compressed by C_trans.
 
     This calculates C_(trans,perm) without allocating C_trans and C_perm.
     Batch calculations are used to reduce memory allocation.
@@ -50,8 +52,20 @@ def compr_permutation_lat_trans_O3(
 
     Return
     ------
-    Compressed basis matrix for permutation
-    C_pt = eigh(C_trans.T @ C_perm @ C_perm.T @ C_trans)
+    c_pt: Compressed basis matrix for permutations and lattice translations.
+          c_pt = eigh(C_trans.T @ C_perm @ C_perm.T @ C_trans)
+          shape: (NNN333//n_lp, n_basis_pt).
+          n_basis_pt denotes the size of basis for permutations and
+          lattice translations.
+
+    Algorithm
+    ---------
+    1. Calculate combinations {(i, a), (j, b), (k, c)}.
+    2. Apply permutations to these combinations and calculate the orbits of
+       {(i, a), (j, b), (k, c)} related to each other by permutations.
+    3. Calculate the lattice translation basis indices of the orbits,
+       and represent the lattice translation indices related to each other
+       by a representative in perm_decompr_idx.
     """
     n_lp, natom = trans_perms.shape
     NNN27 = natom**3 * 27
@@ -61,18 +75,18 @@ def compr_permutation_lat_trans_O3(
     if n_batch is None:
         n_batch = 1 if natom <= 128 else int(round((natom / 128) ** 2))
 
-    orbits = np.ones(NNN27 // n_lp, dtype="int") * -1
+    perm_decompr_idx = np.ones(NNN27 // n_lp, dtype="int") * -1
     indep_atoms = get_indep_atoms_by_lat_trans(trans_perms)
 
     # order = 1
     combinations = np.array([[i, i, i] for i in range(3 * natom)], dtype=int)
     perms = [[0, 0, 0]]
-    orbits = _update_orbits_from_combinations(
+    perm_decompr_idx = _update_perm_decompr_indices(
         combinations,
         perms,
         atomic_decompr_idx,
         trans_perms,
-        orbits,
+        perm_decompr_idx,
         n_perms_group=1,
         n_batch=1,
         verbose=verbose,
@@ -90,12 +104,12 @@ def compr_permutation_lat_trans_O3(
         [1, 0, 1],
         [1, 1, 0],
     ]
-    orbits = _update_orbits_from_combinations(
+    perm_decompr_idx = _update_perm_decompr_indices(
         combinations,
         perms,
         atomic_decompr_idx,
         trans_perms,
-        orbits,
+        perm_decompr_idx,
         n_perms_group=2,
         n_batch=1,
         verbose=verbose,
@@ -113,34 +127,37 @@ def compr_permutation_lat_trans_O3(
         [2, 0, 1],
         [2, 1, 0],
     ]
-    orbits = _update_orbits_from_combinations(
+    perm_decompr_idx = _update_perm_decompr_indices(
         combinations,
         perms,
         atomic_decompr_idx,
         trans_perms,
-        orbits,
+        perm_decompr_idx,
         n_perms_group=1,
         n_batch=n_batch,
         verbose=verbose,
     )
-
-    if verbose:
-        print("Construct basis matrix for permutations", flush=True)
-    c_pt = construct_basis_from_orbits(orbits)
+    c_pt = construct_basis_from_perm_decompr_indices(perm_decompr_idx, verbose=verbose)
     return c_pt
 
 
-def _update_orbits_from_combinations(
+def _update_perm_decompr_indices(
     combinations: np.ndarray,
     permutations: np.ndarray,
     atomic_decompr_idx: np.ndarray,
     trans_perms: np.ndarray,
-    orbits: np.ndarray,
+    perm_decompr_idx: np.ndarray,
     n_perms_group: int = 1,
     n_batch: int = 1,
     verbose: bool = False,
 ) -> csr_array:
-    """Construct projector of permutation and lattice translation."""
+    """Apply permutations to lattice translation basis.
+
+    Return
+    ------
+    perm_decompr_idx: Updated decompression indices of lattice translation basis
+                      using permutations.
+    """
     n_lp, natom = trans_perms.shape
     n_comb = combinations.shape[0]
     n_perms = len(permutations)
@@ -150,8 +167,8 @@ def _update_orbits_from_combinations(
             print("Permutation basis:", str(end) + "/" + str(n_comb), flush=True)
         combs_perm = combinations[begin:end][:, permutations].reshape((-1, 3))
         combs_perm, combs333 = _N3N3N3_to_NNNand333(combs_perm, natom)
-        cols = atomic_decompr_idx[combs_perm] * 27 + combs333
-        cols = cols.reshape(-1, n_perms_sym)
-        for c in cols.T:
-            orbits[c] = cols[:, 0]
-    return orbits
+        decompr_idx_combs_perm = atomic_decompr_idx[combs_perm] * 27 + combs333
+        decompr_idx_combs_perm = decompr_idx_combs_perm.reshape(-1, n_perms_sym)
+        for orbit_components in decompr_idx_combs_perm.T:
+            perm_decompr_idx[orbit_components] = decompr_idx_combs_perm[:, 0]
+    return perm_decompr_idx

--- a/src/symfc/utils/permutation_tools_O4.py
+++ b/src/symfc/utils/permutation_tools_O4.py
@@ -7,8 +7,10 @@ import numpy as np
 from scipy.sparse import csr_array
 
 from symfc.utils.cutoff_tools import FCCutoff
-from symfc.utils.matrix_tools import get_combinations
-from symfc.utils.permutation_tools import construct_basis_from_orbits
+from symfc.utils.permutation_tools import (
+    construct_basis_from_perm_decompr_indices,
+    get_combinations,
+)
 from symfc.utils.solver_funcs import get_batch_slice
 from symfc.utils.utils import get_indep_atoms_by_lat_trans
 from symfc.utils.utils_O4 import get_atomic_lat_trans_decompr_indices_O4
@@ -38,7 +40,7 @@ def compr_permutation_lat_trans_O4(
     n_batch: Optional[int] = None,
     verbose: bool = False,
 ) -> csr_array:
-    """Build a compression matrix for permutation rules compressed by C_trans.
+    r"""Build a compression matrix for permutation rules compressed by C_trans.
 
     This calculates C_(trans,perm) without allocating C_trans and C_perm.
     Batch calculations are used to reduce memory allocation.
@@ -54,26 +56,38 @@ def compr_permutation_lat_trans_O4(
 
     Return
     ------
-    Compressed basis matrix for permutation
-    C_pt = eigh(C_trans.T @ C_perm @ C_perm.T @ C_trans)
+    c_pt: Compressed basis matrix for permutations and lattice translations.
+          c_pt = eigh(C_trans.T @ C_perm @ C_perm.T @ C_trans)
+          shape: (NNNN3333//n_lp, n_basis_pt).
+          n_basis_pt denotes the size of basis for permutations and
+          lattice translations.
+
+    Algorithm
+    ---------
+    1. Calculate combinations {(i, a), (j, b), (k, c)}.
+    2. Apply permutations to these combinations and calculate the orbits of
+       {(i, a), (j, b), (k, c)} related to each other by permutations.
+    3. Calculate the lattice translation basis indices of the orbits,
+       and represent the lattice translation indices related to each other
+       by a representative in perm_decompr_idx.
     """
     n_lp, natom = trans_perms.shape
     NNNN81 = natom**4 * 81
     if atomic_decompr_idx is None:
         atomic_decompr_idx = get_atomic_lat_trans_decompr_indices_O4(trans_perms)
 
-    orbits = np.ones(NNNN81 // n_lp, dtype="int") * -1
+    perm_decompr_idx = np.ones(NNNN81 // n_lp, dtype="int") * -1
     indep_atoms = get_indep_atoms_by_lat_trans(trans_perms)
 
     # order = 1
     combinations = np.array([[i, i, i] for i in range(3 * natom)], dtype=int)
     perms = [[0, 0, 0, 0]]
-    orbits = _update_orbits_from_combinations(
+    perm_decompr_idx = _update_perm_decompr_indices(
         combinations,
         perms,
         atomic_decompr_idx,
         trans_perms,
-        orbits,
+        perm_decompr_idx,
         n_perms_group=1,
         n_batch=1,
         verbose=verbose,
@@ -93,12 +107,12 @@ def compr_permutation_lat_trans_O4(
         [1, 0, 1, 1],
         [0, 1, 1, 1],
     ]
-    orbits = _update_orbits_from_combinations(
+    perm_decompr_idx = _update_perm_decompr_indices(
         combinations,
         perms,
         atomic_decompr_idx,
         trans_perms,
-        orbits,
+        perm_decompr_idx,
         n_perms_group=2,
         n_batch=1,
         verbose=verbose,
@@ -149,12 +163,12 @@ def compr_permutation_lat_trans_O4(
         [1, 0, 2, 2],
         [0, 1, 2, 2],
     ]
-    orbits = _update_orbits_from_combinations(
+    perm_decompr_idx = _update_perm_decompr_indices(
         combinations,
         perms,
         atomic_decompr_idx,
         trans_perms,
-        orbits,
+        perm_decompr_idx,
         n_perms_group=3,
         n_batch=n_batch3,
         verbose=verbose,
@@ -168,33 +182,37 @@ def compr_permutation_lat_trans_O4(
         natom, order=4, fc_cutoff=fc_cutoff, indep_atoms=indep_atoms
     )
     perms = np.array(list(itertools.permutations(range(4))))
-    orbits = _update_orbits_from_combinations(
+    perm_decompr_idx = _update_perm_decompr_indices(
         combinations,
         perms,
         atomic_decompr_idx,
         trans_perms,
-        orbits,
+        perm_decompr_idx,
         n_perms_group=1,
         n_batch=n_batch4,
         verbose=verbose,
     )
-    if verbose:
-        print("Construct basis matrix for permutations", flush=True)
-    c_pt = construct_basis_from_orbits(orbits)
+    c_pt = construct_basis_from_perm_decompr_indices(perm_decompr_idx, verbose=verbose)
     return c_pt
 
 
-def _update_orbits_from_combinations(
+def _update_perm_decompr_indices(
     combinations: np.ndarray,
     permutations: np.ndarray,
     atomic_decompr_idx: np.ndarray,
     trans_perms: np.ndarray,
-    orbits: np.ndarray,
+    perm_decompr_idx: np.ndarray,
     n_perms_group: int = 1,
     n_batch: int = 1,
     verbose: bool = False,
 ) -> csr_array:
-    """Construct projector of permutation and lattice translation."""
+    """Apply permutations to lattice translation basis.
+
+    Return
+    ------
+    perm_decompr_idx: Updated decompression indices of lattice translation basis
+                      using permutations.
+    """
     n_lp, natom = trans_perms.shape
     n_comb = combinations.shape[0]
     n_perms = len(permutations)
@@ -204,8 +222,8 @@ def _update_orbits_from_combinations(
             print("Permutation basis:", str(end) + "/" + str(n_comb), flush=True)
         combs_perm = combinations[begin:end][:, permutations].reshape((-1, 4))
         combs_perm, combs3333 = _N3N3N3N3_to_NNNNand3333(combs_perm, natom)
-        cols = atomic_decompr_idx[combs_perm] * 81 + combs3333
-        cols = cols.reshape(-1, n_perms_sym)
-        for c in cols.T:
-            orbits[c] = cols[:, 0]
-    return orbits
+        decompr_idx_combs_perm = atomic_decompr_idx[combs_perm] * 81 + combs3333
+        decompr_idx_combs_perm = decompr_idx_combs_perm.reshape(-1, n_perms_sym)
+        for orbit_components in decompr_idx_combs_perm.T:
+            perm_decompr_idx[orbit_components] = decompr_idx_combs_perm[:, 0]
+    return perm_decompr_idx


### PR DESCRIPTION
The docstrings for permutations and eig_tools have been updated. Additionally, functions for calculating combinations have been moved from matrix_tools.py, including the obsolete permutation functions, to permutation_tools.py. Furthermore, variable and function names in permutation_tools*.py have been changed to ensure compatibility with the lattice translation parts.