### PR TITLE
Fix typehint errors

### DIFF
--- a/src/symfc/api_symfc.py
+++ b/src/symfc/api_symfc.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Optional, Union
+from typing import Optional, Union, cast
 
 import numpy as np
 
@@ -63,8 +63,8 @@ class Symfc:
         self._use_mkl = use_mkl
         self._log_level = log_level
 
-        self._basis_set: dict[FCBasisSetBase] = {}
-        self._force_constants: dict[np.ndarray] = {}
+        self._basis_set: dict[int, FCBasisSetBase] = {}
+        self._force_constants: dict[int, np.ndarray] = {}
         self._prepare_cutoff(cutoff)
 
     @property
@@ -81,7 +81,7 @@ class Symfc:
             raise ValueError("No FCBasisSet set is not set.")
 
     @property
-    def basis_set(self) -> dict[FCBasisSetBase]:
+    def basis_set(self) -> dict[int, FCBasisSetBase]:
         """Setter and getter of basis set.
 
         dict[FCBasisSet]
@@ -95,7 +95,7 @@ class Symfc:
         self._basis_set = basis_set
 
     @property
-    def force_constants(self) -> dict[np.ndarray]:
+    def force_constants(self) -> dict[int, np.ndarray]:
         """Return force constants.
 
         Returns
@@ -107,7 +107,7 @@ class Symfc:
         return self._force_constants
 
     @property
-    def displacements(self) -> np.ndarray:
+    def displacements(self) -> Optional[np.ndarray]:
         """Setter and getter of supercell displacements.
 
         ndarray
@@ -121,7 +121,7 @@ class Symfc:
         self._displacements = np.array(displacements, dtype="double", order="C")
 
     @property
-    def forces(self) -> np.ndarray:
+    def forces(self) -> Optional[np.ndarray]:
         """Setter and getter of supercell forces.
 
         ndarray
@@ -185,82 +185,111 @@ class Symfc:
             Batch size in solvers, by default 100.
         """
         self._check_dataset()
-        orders = self._check_orders(max_order, orders)
+        _orders = self._check_orders(max_order, orders)
 
-        if orders == (2,):
-            basis_set: FCBasisSetO2 = self._basis_set[2]
+        if self._displacements is None:
+            raise RuntimeError("Displacements not found.")
+        if self._forces is None:
+            raise RuntimeError("Forces not found.")
+
+        if _orders == (2,):
+            basis_set_o2: FCBasisSetO2 = cast(FCBasisSetO2, self._basis_set[2])
             solver_o2 = FCSolverO2(
-                basis_set,
+                basis_set_o2,
                 use_mkl=self._use_mkl,
                 log_level=self._log_level,
             ).solve(self._displacements, self._forces)
             if is_compact_fc:
-                self._force_constants[2] = solver_o2.compact_fc
+                if solver_o2.compact_fc is not None:
+                    self._force_constants[2] = solver_o2.compact_fc
+                else:
+                    raise RuntimeError("Failed to obtain compact force constants")
             else:
-                self._force_constants[2] = solver_o2.full_fc
-        elif orders == (3,):
-            basis_set: FCBasisSetO3 = self._basis_set[3]
+                if solver_o2.full_fc is not None:
+                    self._force_constants[2] = solver_o2.full_fc
+                else:
+                    raise RuntimeError("Failed to obtain full force constants")
+        elif _orders == (3,):
+            basis_set_o3: FCBasisSetO3 = cast(FCBasisSetO3, self._basis_set[3])
             solver_o3 = FCSolverO3(
-                basis_set,
+                basis_set_o3,
                 use_mkl=self._use_mkl,
                 log_level=self._log_level,
             ).solve(self._displacements, self._forces)
             if is_compact_fc:
-                self._force_constants[3] = solver_o3.compact_fc
+                if solver_o3.compact_fc is not None:
+                    self._force_constants[3] = solver_o3.compact_fc
+                else:
+                    raise RuntimeError("Failed to obtain compact force constants")
             else:
-                self._force_constants[3] = solver_o3.full_fc
-        elif orders == (4,):
-            basis_set: FCBasisSetO4 = self._basis_set[4]
+                if solver_o3.full_fc is not None:
+                    self._force_constants[3] = solver_o3.full_fc
+                else:
+                    raise RuntimeError("Failed to obtain full force constants")
+        elif _orders == (4,):
+            basis_set_o4: FCBasisSetO4 = cast(FCBasisSetO4, self._basis_set[4])
             solver_o4 = FCSolverO4(
-                basis_set,
+                basis_set_o4,
                 use_mkl=self._use_mkl,
                 log_level=self._log_level,
             ).solve(self._displacements, self._forces)
             if is_compact_fc:
-                self._force_constants[4] = solver_o4.compact_fc
+                if solver_o4.compact_fc is not None:
+                    self._force_constants[4] = solver_o4.compact_fc
+                else:
+                    raise RuntimeError("Failed to obtain compact force constants")
             else:
-                self._force_constants[4] = solver_o4.full_fc
-        elif orders == (2, 3):
-            basis_set_o2: FCBasisSetO2 = self._basis_set[2]
-            basis_set_o3: FCBasisSetO3 = self._basis_set[3]
+                if solver_o4.full_fc is not None:
+                    self._force_constants[4] = solver_o4.full_fc
+                else:
+                    raise RuntimeError("Failed to obtain full force constants")
+        elif _orders == (2, 3):
+            basis_set_o2: FCBasisSetO2 = cast(FCBasisSetO2, self._basis_set[2])
+            basis_set_o3: FCBasisSetO3 = cast(FCBasisSetO3, self._basis_set[3])
             solver_o2o3 = FCSolverO2O3(
                 [basis_set_o2, basis_set_o3],
                 use_mkl=self._use_mkl,
                 log_level=self._log_level,
             ).solve(self._displacements, self._forces, batch_size=batch_size)
-            if is_compact_fc:
+            if is_compact_fc and solver_o2o3.compact_fc is not None:
                 fc2, fc3 = solver_o2o3.compact_fc
-            else:
+            elif solver_o2o3.full_fc is not None:
                 fc2, fc3 = solver_o2o3.full_fc
+            else:
+                raise RuntimeError("Failed to obtain force constants")
             self._force_constants[2] = fc2
             self._force_constants[3] = fc3
-        elif orders == (3, 4):
-            basis_set_o3: FCBasisSetO3 = self._basis_set[3]
-            basis_set_o4: FCBasisSetO4 = self._basis_set[4]
+        elif _orders == (3, 4):
+            basis_set_o3: FCBasisSetO3 = cast(FCBasisSetO3, self._basis_set[3])
+            basis_set_o4: FCBasisSetO4 = cast(FCBasisSetO4, self._basis_set[4])
             solver_o3o4 = FCSolverO3O4(
                 [basis_set_o3, basis_set_o4],
                 use_mkl=self._use_mkl,
                 log_level=self._log_level,
             ).solve(self._displacements, self._forces, batch_size=batch_size)
-            if is_compact_fc:
+            if is_compact_fc and solver_o3o4.compact_fc is not None:
                 fc3, fc4 = solver_o3o4.compact_fc
-            else:
+            elif solver_o3o4.full_fc is not None:
                 fc3, fc4 = solver_o3o4.full_fc
+            else:
+                raise RuntimeError("Failed to obtain force constants")
             self._force_constants[3] = fc3
             self._force_constants[4] = fc4
-        elif orders == (2, 3, 4):
-            basis_set_o2: FCBasisSetO2 = self._basis_set[2]
-            basis_set_o3: FCBasisSetO3 = self._basis_set[3]
-            basis_set_o4: FCBasisSetO4 = self._basis_set[4]
+        elif _orders == (2, 3, 4):
+            basis_set_o2: FCBasisSetO2 = cast(FCBasisSetO2, self._basis_set[2])
+            basis_set_o3: FCBasisSetO3 = cast(FCBasisSetO3, self._basis_set[3])
+            basis_set_o4: FCBasisSetO4 = cast(FCBasisSetO4, self._basis_set[4])
             solver_o2o3o4 = FCSolverO2O3O4(
                 [basis_set_o2, basis_set_o3, basis_set_o4],
                 use_mkl=self._use_mkl,
                 log_level=self._log_level,
             ).solve(self._displacements, self._forces, batch_size=batch_size)
-            if is_compact_fc:
+            if is_compact_fc and solver_o2o3o4.compact_fc is not None:
                 fc2, fc3, fc4 = solver_o2o3o4.compact_fc
-            else:
+            elif solver_o2o3o4.full_fc is not None:
                 fc2, fc3, fc4 = solver_o2o3o4.full_fc
+            else:
+                raise RuntimeError("Failed to obtain force constants")
             self._force_constants[2] = fc2
             self._force_constants[3] = fc3
             self._force_constants[4] = fc4
@@ -365,7 +394,7 @@ class Symfc:
 
         return basis_size_estimates
 
-    def _check_orders(self, max_order: int, orders: list) -> tuple:
+    def _check_orders(self, max_order: Optional[int], orders: Optional[list]) -> tuple:
         if max_order is None and orders is None:
             raise RuntimeError("Maximum order and orders not found.")
 
@@ -374,12 +403,12 @@ class Symfc:
                 raise NotImplementedError(
                     "Only fc2, fc3 and fc4 basis sets are implemented."
                 )
-            orders = tuple(list(range(2, max_order + 1)))
-        else:
-            orders = tuple(sorted(orders))
-            if orders not in [(2,), (3,), (4,), (2, 3), (3, 4), (2, 3, 4)]:
+            _orders = tuple(list(range(2, max_order + 1)))
+        elif orders is not None:
+            _orders = tuple(sorted(orders))
+            if _orders not in [(2,), (3,), (4,), (2, 3), (3, 4), (2, 3, 4)]:
                 raise RuntimeError("Invalid FC orders.")
-        return orders
+        return _orders
 
     def _check_dataset(self):
         if self._displacements is None:

--- a/src/symfc/basis_sets/basis_sets_O2.py
+++ b/src/symfc/basis_sets/basis_sets_O2.py
@@ -79,7 +79,7 @@ class FCBasisSetO2(FCBasisSetBase):
 
         """
         super().__init__(supercell, use_mkl=use_mkl, log_level=log_level)
-        self._spg_reps = SpgRepsO2(
+        self._spg_reps: SpgRepsO2 = SpgRepsO2(
             supercell, spacegroup_operations=spacegroup_operations
         )
         if cutoff is None:
@@ -109,6 +109,10 @@ class FCBasisSetO2(FCBasisSetBase):
         This expands fc basis_sets to (N*N*3*3, n_bases).
 
         """
+        if self._n_a_compression_matrix is None:
+            raise ValueError(
+                "Compression matrix is not computed. Call run() method to compute it."
+            )
         trans_perms = self._spg_reps.translation_permutations
         c_trans = get_lat_trans_compr_matrix_O2(trans_perms)
         return dot_product_sparse(
@@ -202,5 +206,5 @@ class FCBasisSetO2(FCBasisSetBase):
             verbose=False,
         )
         n_sym_prim = len(self._spg_reps._unique_rotations)
-        basis_size_estimates = c_pt.shape[1] / n_sym_prim
+        basis_size_estimates = c_pt.shape[1] / n_sym_prim  # type: ignore
         return int(np.round(basis_size_estimates).astype(int))

--- a/src/symfc/basis_sets/basis_sets_base.py
+++ b/src/symfc/basis_sets/basis_sets_base.py
@@ -33,8 +33,7 @@ class FCBasisSetBase(ABC):
         self._natom = len(supercell)
         self._use_mkl = use_mkl
         self._log_level = log_level
-        self._basis_set: Optional[np.ndarray] = None
-        self._spg_reps: Optional[SpgRepsBase] = None
+        self._spg_reps: SpgRepsBase
         self._supercell = supercell
 
     @property
@@ -67,7 +66,9 @@ class FCBasisSetBase(ABC):
         """Return indices of translationally independent atoms."""
         if self._spg_reps is None:
             raise ValueError("SpgRepsBase is not set.")
-        return self._spg_reps._p2s_map
+        if self._spg_reps.p2s_map is None:
+            raise ValueError("p2s_map is not set.")
+        return self._spg_reps.p2s_map
 
     @abstractmethod
     def run(self):

--- a/src/symfc/solvers/solver_O2O3.py
+++ b/src/symfc/solvers/solver_O2O3.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import time
 from collections.abc import Sequence
-from typing import Literal, Optional
+from typing import Literal, Optional, Union, cast
 
 import numpy as np
 from scipy.sparse import csr_array
@@ -22,12 +22,30 @@ class FCSolverO2O3(FCSolverBase):
 
     def __init__(
         self,
-        basis_set: Sequence[FCBasisSetO2, FCBasisSetO3],
+        basis_set: Sequence[Union[FCBasisSetO2, FCBasisSetO3]],
         use_mkl: bool = False,
         log_level: int = 0,
     ):
-        """Init method."""
+        """Init method.
+
+        Parameters
+        ----------
+        basis_set : Sequence of (FCBasisSetO2, FCBasisSetO3)
+            First element must be FCBasisSetO2 and second must be FCBasisSetO3.
+        use_mkl : bool, optional
+            Use MKL if True. Default is False.
+        log_level : int, optional
+            Logging level. Default is 0.
+
+        """
+        if len(basis_set) != 2:
+            raise ValueError("basis_set must contain exactly 2 elements")
+        if not isinstance(basis_set[0], FCBasisSetO2):
+            raise TypeError("First element must be FCBasisSetO2")
+        if not isinstance(basis_set[1], FCBasisSetO3):
+            raise TypeError("Second element must be FCBasisSetO3")
         super().__init__(basis_set, use_mkl=use_mkl, log_level=log_level)
+        self._basis_set: Sequence[Union[FCBasisSetO2, FCBasisSetO3]]
 
     def solve(
         self,
@@ -61,8 +79,8 @@ class FCSolverO2O3(FCSolverBase):
         f = forces.reshape(n_data, -1)
         d = displacements.reshape(n_data, -1)
 
-        fc2_basis: FCBasisSetO2 = self._basis_set[0]
-        fc3_basis: FCBasisSetO3 = self._basis_set[1]
+        fc2_basis: FCBasisSetO2 = cast(FCBasisSetO2, self._basis_set[0])
+        fc3_basis: FCBasisSetO3 = cast(FCBasisSetO3, self._basis_set[1])
         compress_mat_fc2 = fc2_basis.compact_compression_matrix
         basis_set_fc2 = fc2_basis.basis_set
         compress_mat_fc3 = fc3_basis.compact_compression_matrix
@@ -71,6 +89,16 @@ class FCSolverO2O3(FCSolverBase):
         atomic_decompr_idx_fc2 = fc2_basis.atomic_decompr_idx
         atomic_decompr_idx_fc3 = fc3_basis.atomic_decompr_idx
 
+        if (
+            compress_mat_fc2 is None
+            or compress_mat_fc3 is None
+            or basis_set_fc2 is None
+            or basis_set_fc3 is None
+        ):
+            raise ValueError(
+                "Compression matrices or basis sets are not set. "
+                "Call run() method to compute them."
+            )
         self._coefs = run_solver_O2O3(
             d,
             f,
@@ -114,13 +142,13 @@ class FCSolverO2O3(FCSolverBase):
 
     def _recover_fcs(
         self,
-        comp_mat_type: str = Literal["full", "compact"],
+        comp_mat_type: Literal["full", "compact"],
     ) -> Optional[tuple[np.ndarray, np.ndarray]]:
         if self._coefs is None:
             return None
 
-        fc2_basis: FCBasisSetO2 = self._basis_set[0]
-        fc3_basis: FCBasisSetO3 = self._basis_set[1]
+        fc2_basis: FCBasisSetO2 = cast(FCBasisSetO2, self._basis_set[0])
+        fc3_basis: FCBasisSetO3 = cast(FCBasisSetO3, self._basis_set[1])
         if comp_mat_type == "full":
             comp_mat_fc2 = fc2_basis.compression_matrix
             comp_mat_fc3 = fc3_basis.compression_matrix
@@ -228,8 +256,8 @@ def prepare_normal_equation_O2O3(
     N = N3 // 3
     NN = N * N
 
-    n_compr_fc2 = compact_compress_mat_fc2.shape[1]
-    n_compr_fc3 = compact_compress_mat_fc3.shape[1]
+    n_compr_fc2 = compact_compress_mat_fc2.shape[1]  # type: ignore
+    n_compr_fc3 = compact_compress_mat_fc3.shape[1]  # type: ignore
 
     n_batch = (N // 256 + 1) * (n_compr_fc3 // 30000 + 1)
     n_batch = min(N, n_batch)

--- a/src/symfc/solvers/solver_O2O3O4.py
+++ b/src/symfc/solvers/solver_O2O3O4.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import time
 from collections.abc import Sequence
-from typing import Literal, Optional
+from typing import Literal, Optional, Union, cast
 
 import numpy as np
 from scipy.sparse import csr_array
@@ -23,12 +23,33 @@ class FCSolverO2O3O4(FCSolverBase):
 
     def __init__(
         self,
-        basis_set: Sequence[FCBasisSetO2, FCBasisSetO3, FCBasisSetO4],
+        basis_set: Sequence[Union[FCBasisSetO2, FCBasisSetO3, FCBasisSetO4]],
         use_mkl: bool = False,
         log_level: int = 0,
     ):
-        """Init method."""
+        """Init method.
+
+        Parameters
+        ----------
+        basis_set : Sequence of (FCBasisSetO2, FCBasisSetO3, FCBasisSetO4)
+            First element must be FCBasisSetO2, second must be FCBasisSetO3,
+            and third must be FCBasisSetO4.
+        use_mkl : bool, optional
+            Use MKL if True. Default is False.
+        log_level : int, optional
+            Logging level. Default is 0.
+
+        """
+        if len(basis_set) != 3:
+            raise ValueError("basis_set must contain exactly 3 elements")
+        if not isinstance(basis_set[0], FCBasisSetO2):
+            raise TypeError("First element must be FCBasisSetO2")
+        if not isinstance(basis_set[1], FCBasisSetO3):
+            raise TypeError("Second element must be FCBasisSetO3")
+        if not isinstance(basis_set[2], FCBasisSetO4):
+            raise TypeError("Third element must be FCBasisSetO4")
         super().__init__(basis_set, use_mkl=use_mkl, log_level=log_level)
+        self._basis_set: Sequence[Union[FCBasisSetO2, FCBasisSetO3, FCBasisSetO4]]
 
     def solve(
         self,
@@ -62,9 +83,9 @@ class FCSolverO2O3O4(FCSolverBase):
         f = forces.reshape(n_data, -1)
         d = displacements.reshape(n_data, -1)
 
-        fc2_basis: FCBasisSetO2 = self._basis_set[0]
-        fc3_basis: FCBasisSetO3 = self._basis_set[1]
-        fc4_basis: FCBasisSetO4 = self._basis_set[2]
+        fc2_basis: FCBasisSetO2 = cast(FCBasisSetO2, self._basis_set[0])
+        fc3_basis: FCBasisSetO3 = cast(FCBasisSetO3, self._basis_set[1])
+        fc4_basis: FCBasisSetO4 = cast(FCBasisSetO4, self._basis_set[2])
         compress_mat_fc2 = fc2_basis.compact_compression_matrix
         basis_set_fc2 = fc2_basis.basis_set
         compress_mat_fc3 = fc3_basis.compact_compression_matrix
@@ -95,7 +116,7 @@ class FCSolverO2O3O4(FCSolverBase):
         return self
 
     @property
-    def full_fc(self) -> Optional[tuple[np.ndarray, np.ndarray]]:
+    def full_fc(self) -> Optional[tuple[np.ndarray, np.ndarray, np.ndarray]]:
         """Return full force constants.
 
         Returns
@@ -109,7 +130,7 @@ class FCSolverO2O3O4(FCSolverBase):
         return self._recover_fcs("full")
 
     @property
-    def compact_fc(self) -> Optional[tuple[np.ndarray, np.ndarray]]:
+    def compact_fc(self) -> Optional[tuple[np.ndarray, np.ndarray, np.ndarray]]:
         """Return full force constants.
 
         Returns
@@ -123,14 +144,14 @@ class FCSolverO2O3O4(FCSolverBase):
         return self._recover_fcs("compact")
 
     def _recover_fcs(
-        self, comp_mat_type: str = Literal["full", "compact"]
-    ) -> Optional[tuple[np.ndarray, np.ndarray]]:
+        self, comp_mat_type: Literal["full", "compact"]
+    ) -> Optional[tuple[np.ndarray, np.ndarray, np.ndarray]]:
         if self._coefs is None:
             return None
 
-        fc2_basis: FCBasisSetO2 = self._basis_set[0]
-        fc3_basis: FCBasisSetO3 = self._basis_set[1]
-        fc4_basis: FCBasisSetO4 = self._basis_set[2]
+        fc2_basis: FCBasisSetO2 = cast(FCBasisSetO2, self._basis_set[0])
+        fc3_basis: FCBasisSetO3 = cast(FCBasisSetO3, self._basis_set[1])
+        fc4_basis: FCBasisSetO4 = cast(FCBasisSetO4, self._basis_set[2])
         if comp_mat_type == "full":
             comp_mat_fc2 = fc2_basis.compression_matrix
             comp_mat_fc3 = fc3_basis.compression_matrix

--- a/src/symfc/solvers/solver_O3O4.py
+++ b/src/symfc/solvers/solver_O3O4.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import time
 from collections.abc import Sequence
-from typing import Literal, Optional
+from typing import Literal, Optional, Union, cast
 
 import numpy as np
 
@@ -25,12 +25,30 @@ class FCSolverO3O4(FCSolverBase):
 
     def __init__(
         self,
-        basis_set: Sequence[FCBasisSetO3, FCBasisSetO4],
+        basis_set: Sequence[Union[FCBasisSetO3, FCBasisSetO4]],
         use_mkl: bool = False,
         log_level: int = 0,
     ):
-        """Init method."""
+        """Init method.
+
+        Parameters
+        ----------
+        basis_set : Sequence of (FCBasisSetO3, FCBasisSetO4)
+            First element must be FCBasisSetO3 and second must be FCBasisSetO4.
+        use_mkl : bool, optional
+            Use MKL if True. Default is False.
+        log_level : int, optional
+            Logging level. Default is 0.
+
+        """
+        if len(basis_set) != 2:
+            raise ValueError("basis_set must contain exactly 2 elements")
+        if not isinstance(basis_set[0], FCBasisSetO3):
+            raise TypeError("First element must be FCBasisSetO3")
+        if not isinstance(basis_set[1], FCBasisSetO4):
+            raise TypeError("Second element must be FCBasisSetO4")
         super().__init__(basis_set, use_mkl=use_mkl, log_level=log_level)
+        self._basis_set: Sequence[Union[FCBasisSetO3, FCBasisSetO4]]
 
     def solve(
         self,
@@ -62,8 +80,8 @@ class FCSolverO3O4(FCSolverBase):
         f = forces.reshape(n_data, -1)
         d = displacements.reshape(n_data, -1)
 
-        fc3_basis: FCBasisSetO3 = self._basis_set[0]
-        fc4_basis: FCBasisSetO4 = self._basis_set[1]
+        fc3_basis: FCBasisSetO3 = cast(FCBasisSetO3, self._basis_set[0])
+        fc4_basis: FCBasisSetO4 = cast(FCBasisSetO4, self._basis_set[1])
         compress_mat_fc3 = fc3_basis.compact_compression_matrix
         basis_set_fc3 = fc3_basis.basis_set
         compress_mat_fc4 = fc4_basis.compact_compression_matrix
@@ -114,13 +132,13 @@ class FCSolverO3O4(FCSolverBase):
         return self._recover_fcs("compact")
 
     def _recover_fcs(
-        self, comp_mat_type: str = Literal["full", "compact"]
+        self, comp_mat_type: Literal["full", "compact"]
     ) -> Optional[tuple[np.ndarray, np.ndarray]]:
         if self._coefs is None:
             return None
 
-        fc3_basis: FCBasisSetO3 = self._basis_set[0]
-        fc4_basis: FCBasisSetO4 = self._basis_set[1]
+        fc3_basis: FCBasisSetO3 = cast(FCBasisSetO3, self._basis_set[0])
+        fc4_basis: FCBasisSetO4 = cast(FCBasisSetO4, self._basis_set[1])
         if comp_mat_type == "full":
             comp_mat_fc3 = fc3_basis.compression_matrix
             comp_mat_fc4 = fc4_basis.compression_matrix

--- a/src/symfc/solvers/solver_base.py
+++ b/src/symfc/solvers/solver_base.py
@@ -21,18 +21,19 @@ class FCSolverBase(ABC):
         log_level: int = 0,
     ):
         """Init method."""
-        self._basis_set: FCBasisSetBase = basis_set
-        self._use_mkl: bool = use_mkl
-        self._log_level: int = log_level
+        self._basis_set = basis_set
+        self._use_mkl = use_mkl
+        self._log_level = log_level
         if isinstance(self._basis_set, Sequence):
-            _basis_set: FCBasisSetBase = self._basis_set[0]
+            _basis_set = self._basis_set[0]
         else:
             _basis_set = basis_set
-        self._natom: int = _basis_set.translation_permutations.shape[1]
+        assert isinstance(_basis_set, FCBasisSetBase)
+        self._natom = _basis_set.translation_permutations.shape[1]
         self._coefs: Optional[Union[np.ndarray, Sequence[np.ndarray]]] = None
 
     @property
-    def coefs(self) -> Optional[np.ndarray]:
+    def coefs(self) -> Optional[Union[np.ndarray, Sequence[np.ndarray]]]:
         """Return coefficients of force constants with respect to basis set."""
         return self._coefs
 

--- a/src/symfc/spg_reps/spg_reps_O2.py
+++ b/src/symfc/spg_reps/spg_reps_O2.py
@@ -40,7 +40,7 @@ class SpgRepsO2(SpgRepsBase):
         """Return 2nd rank tensor rotation matricies."""
         return self._r2_reps
 
-    def get_sigma2_rep(self, i: int, nonzero: np.ndarray = None) -> csr_array:
+    def get_sigma2_rep(self, i: int, nonzero: Optional[np.ndarray] = None) -> csr_array:
         """Compute vector representation of i-th atomic pair permutation matrix.
 
         Parameters
@@ -71,7 +71,9 @@ class SpgRepsO2(SpgRepsBase):
             r2_reps.append(csr_array((data, (row, col)), shape=r2_rep.shape))
         self._r2_reps = r2_reps
 
-    def _get_sigma2_rep_data(self, i: int, nonzero: np.ndarray = None) -> csr_array:
+    def _get_sigma2_rep_data(
+        self, i: int, nonzero: Optional[np.ndarray] = None
+    ) -> csr_array:
         """Compute vector representation of i-th atomic pair permutation matrix.
 
         Operation permutation[self._atom_pairs @ self._coeff is divided
@@ -155,7 +157,7 @@ class SpgRepsO2MatrixReps(SpgRepsBase):
             r2_reps.append(csr_array((data, (row, col)), shape=r2_rep.shape))
         self._r2_reps = r2_reps
 
-    def _get_sigma2_rep_data(self, i: int) -> csr_array:
+    def _get_sigma2_rep_data(self, i: int) -> tuple:
         uri = self._unique_rotation_indices
         permutation = self._permutations[uri[i]]
         NN = len(self._numbers) ** 2

--- a/src/symfc/spg_reps/spg_reps_O3.py
+++ b/src/symfc/spg_reps/spg_reps_O3.py
@@ -39,7 +39,9 @@ class SpgRepsO3(SpgRepsBase):
         """Return 3rd rank tensor rotation matricies."""
         return self._r3_reps
 
-    def get_sigma3_rep(self, i: int, nonzero: np.ndarray = None) -> np.ndarray:
+    def get_sigma3_rep(
+        self, i: int, nonzero: Optional[np.ndarray] = None
+    ) -> np.ndarray:
         """Compute vector representation of i-th atomic pair permutation matrix.
 
         Parameters
@@ -71,7 +73,9 @@ class SpgRepsO3(SpgRepsBase):
             r3_reps.append(csr_array((data, (row, col)), shape=r3_rep.shape))
         self._r3_reps = r3_reps
 
-    def _get_sigma3_rep_data(self, i: int, nonzero: np.ndarray = None) -> np.ndarray:
+    def _get_sigma3_rep_data(
+        self, i: int, nonzero: Optional[np.ndarray] = None
+    ) -> np.ndarray:
         """Compute vector representation of i-th atomic pair permutation matrix.
 
         Operation permutation[self._atom_triplets] @ self._coeff is divided

--- a/src/symfc/spg_reps/spg_reps_O4.py
+++ b/src/symfc/spg_reps/spg_reps_O4.py
@@ -39,7 +39,9 @@ class SpgRepsO4(SpgRepsBase):
         """Return 4th rank tensor rotation matricies."""
         return self._r4_reps
 
-    def get_sigma4_rep(self, i: int, nonzero: np.ndarray = None) -> np.ndarray:
+    def get_sigma4_rep(
+        self, i: int, nonzero: Optional[np.ndarray] = None
+    ) -> np.ndarray:
         """Compute vector representation of i-th atomic pair permutation matrix.
 
         Parameters
@@ -71,7 +73,9 @@ class SpgRepsO4(SpgRepsBase):
             r4_reps.append(csr_array((data, (row, col)), shape=r4_rep.shape))
         self._r4_reps = r4_reps
 
-    def _get_sigma4_rep_data(self, i: int, nonzero: np.ndarray = None) -> np.ndarray:
+    def _get_sigma4_rep_data(
+        self, i: int, nonzero: Optional[np.ndarray] = None
+    ) -> np.ndarray:
         """Compute vector representation of i-th atomic pair permutation matrix.
 
         Operation permutation[self._atom_quadruplets] @ self._coeff is divided

--- a/src/symfc/utils/cutoff_tools.py
+++ b/src/symfc/utils/cutoff_tools.py
@@ -234,8 +234,8 @@ class FCCutoff:
         except ImportError as exc:
             raise ModuleNotFoundError("Spglib python module was not found.") from exc
 
-        reduced_bases = spglib.niggli_reduce(self._supercell.cell)
-        trans_mat_float = self._supercell.cell @ np.linalg.inv(reduced_bases)
+        reduced_bases = spglib.niggli_reduce(self._supercell.cell)  # type: ignore
+        trans_mat_float = self._supercell.cell @ np.linalg.inv(reduced_bases)  # type: ignore
         trans_mat = np.rint(trans_mat_float).astype(int)
         assert (np.abs(trans_mat_float - trans_mat) < 1e-8).all()
 

--- a/src/symfc/utils/eig_tools.py
+++ b/src/symfc/utils/eig_tools.py
@@ -2,7 +2,7 @@
 
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Union
 
 import numpy as np
 import scipy
@@ -18,8 +18,8 @@ except ImportError:
 
 
 def dot_product_sparse(
-    A: csr_array,
-    B: csr_array,
+    A: Union[np.ndarray, csr_array],
+    B: Union[np.ndarray, csr_array],
     use_mkl: bool = False,
     dense: bool = False,
 ) -> csr_array:
@@ -29,9 +29,9 @@ def dot_product_sparse(
     return A @ B
 
 
-def _compr_projector(p: csr_array) -> csr_array:
+def _compr_projector(p: csr_array) -> tuple[csr_array, Optional[csr_array]]:
     """Compress projection matrix p with many zero rows and columns."""
-    _, col_p = p.nonzero()
+    _, col_p = p.nonzero()  # type: ignore
     col_p = np.unique(col_p)
     size = len(col_p)
 
@@ -124,6 +124,8 @@ class DataCSR:
 
     def get_data(self, idx: int):
         """Get data in projector for i-th block."""
+        if self.slice_begin is None or self.slice_end is None:
+            raise ValueError("Slice begin and end are not initialized.")
         s1 = self.slice_begin[idx]
         s2 = self.slice_end[idx]
         return self.data[s1:s2]
@@ -160,7 +162,7 @@ def _extract_sparse_projector_data(p: csr_array, group: dict) -> DataCSR:
 
     p_data = DataCSR(
         data=np.ravel(p[r, c]),
-        block_labels=list(group.keys()),
+        block_labels=np.array(list(group.keys())),
         block_sizes=sizes,
     )
     return p_data
@@ -170,7 +172,12 @@ def eigh_projector(
     p: np.ndarray,
     return_complement: bool = False,
     verbose: bool = True,
-) -> np.ndarray:
+) -> Union[
+    np.ndarray,
+    tuple[np.ndarray, tuple[np.ndarray, np.ndarray]],
+    None,
+    tuple[None, None],
+]:
     """Solve eigenvalue problem using numpy and eliminate eigenvectors with e < 1.0."""
     rank = int(round(np.trace(p)))
     if rank == 0:
@@ -242,7 +249,7 @@ def eigsh_projector(p: csr_array, verbose: bool = True) -> csr_array:
                 else:
                     uniq_eigvecs["one"] = [np.array([[1.0]]), [block_label]]
 
-    c_p = _recover_eigvecs_from_uniq_eigvecs(uniq_eigvecs, group, p.shape[0])
+    c_p = _recover_eigvecs_from_uniq_eigvecs(uniq_eigvecs, group, p.shape[0])  # type: ignore
     if compr_p is not None:
         return compr_p @ c_p
     return c_p
@@ -265,11 +272,14 @@ def _block_eigh_projector(p_block: np.ndarray, verbose: bool = False):
         p_small = p_block[begin:end, begin:end]
         rank = int(round(np.trace(p_small)))
         if rank > 0:
-            eigvecs, (cmplt_eigvals, cmplt_small) = eigh_projector(
+            result = eigh_projector(
                 p_small,
                 return_complement=True,
                 verbose=verbose,
             )
+            assert result is not None
+            assert result[0] is not None
+            eigvecs, (cmplt_eigvals, cmplt_small) = result
             col_end = col_id + eigvecs.shape[1]
             col_end_cmplt = col_id_cmplt + cmplt_small.shape[1]
             eigvecs_block[begin:end, col_id:col_end] = eigvecs
@@ -287,10 +297,11 @@ def _block_eigh_projector(p_block: np.ndarray, verbose: bool = False):
         cmplt = cmplt[:, :col_end_cmplt]
         p_block_rem = cmplt.T @ p_block @ cmplt
         eigvecs = eigh_projector(p_block_rem, verbose=verbose)
+        eigvecs_shape1 = eigvecs.shape[1]  # type: ignore
         if verbose:
-            print(eigvecs.shape[1], "eigenvectors are found.", flush=True)
-        if eigvecs.shape[1] > 0:
-            col_end = col_id + eigvecs.shape[1]
+            print(eigvecs_shape1, "eigenvectors are found.", flush=True)
+        if eigvecs_shape1 > 0:
+            col_end = col_id + eigvecs_shape1
             eigvecs_block[:, col_id:col_end] = cmplt @ eigvecs
             col_id = col_end
 
@@ -308,7 +319,7 @@ def eigsh_projector_sumrule(
 
     Return dense matrix for eigenvectors of matrix p.
     """
-    if p.shape[0] > size_threshold:
+    if p.shape[0] > size_threshold:  # type: ignore
         return eigsh_projector_sumrule_large(p, verbose=verbose)
     return eigsh_projector_sumrule_stable(p, verbose=verbose)
 
@@ -333,7 +344,7 @@ def eigsh_projector_sumrule_stable(p: csr_array, verbose: bool = True) -> np.nda
         print("Use standard normal eigsh solver.", flush=True)
         print("Number of blocks in projector (Sum rule):", len(group), flush=True)
 
-    eigvecs_full = np.zeros(p.shape, dtype="double")
+    eigvecs_full = np.zeros(p.shape, dtype="double")  # type: ignore
     col_id = 0
     for i, ids in enumerate(group.values()):
         if verbose:
@@ -343,7 +354,7 @@ def eigsh_projector_sumrule_stable(p: csr_array, verbose: bool = True) -> np.nda
         rank = int(round(np.trace(p_block)))
         if rank > 0:
             eigvecs = eigh_projector(p_block, verbose=verbose)
-            col_end = col_id + eigvecs.shape[1]
+            col_end = col_id + eigvecs.shape[1]  # type: ignore
             eigvecs_full[ids, col_id:col_end] = eigvecs
             col_id = col_end
     return eigvecs_full[:, :col_id]
@@ -382,7 +393,7 @@ def eigsh_projector_sumrule_large(p: csr_array, verbose: bool = True) -> np.ndar
         print("Use eigsh solver for large matrices.", flush=True)
         print("Number of blocks in projector (Sum rule):", len(group), flush=True)
 
-    eigvecs_full = np.zeros(p.shape, dtype="double")
+    eigvecs_full = np.zeros(p.shape, dtype="double")  # type: ignore
     col_id = 0
     for i, ids in enumerate(group.values()):
         if verbose and len(ids) > 2:

--- a/src/symfc/utils/matrix_tools_O2.py
+++ b/src/symfc/utils/matrix_tools_O2.py
@@ -19,7 +19,7 @@ except ImportError:
     pass
 
 
-def N3N3_to_NNand33(combs: np.ndarray, N: int) -> np.ndarray:
+def N3N3_to_NNand33(combs: np.ndarray, N: int) -> tuple[np.ndarray, np.ndarray]:
     """Transform index order."""
     vecNN, vec33 = np.divmod(combs[:, 0], 3)
     vecNN *= N
@@ -96,7 +96,7 @@ def projector_permutation_lat_trans_O2(
     return proj_pt
 
 
-def optimize_batch_size_sum_rules_O2(natom: int, n_batch: Optional[int] = None):
+def optimize_batch_size_sum_rules_O2(natom: int, n_batch: int):
     """Calculate batch size for constructing projector for sum rules."""
     if n_batch > natom:
         raise ValueError("n_batch must be smaller than N.")
@@ -178,7 +178,7 @@ def compressed_projector_sum_rules_O2(
     NN9 = natom**2 * 9
     NN = natom**2
 
-    proj_size = n_a_compress_mat.shape[1]
+    proj_size = n_a_compress_mat.shape[1]  # type: ignore
     proj_cplmt = csr_array((proj_size, proj_size), dtype="double")
 
     if atomic_decompr_idx is None:
@@ -299,7 +299,7 @@ def compressed_projector_sum_rules_O2_stable(
     NN9 = natom**2 * 9
     NN = natom**2
 
-    proj_size = n_a_compress_mat.shape[1]
+    proj_size = n_a_compress_mat.shape[1]  # type: ignore
     proj_cplmt = csr_array((proj_size, proj_size), dtype="double")
 
     if atomic_decompr_idx is None:

--- a/src/symfc/utils/matrix_tools_O3.py
+++ b/src/symfc/utils/matrix_tools_O3.py
@@ -1,6 +1,6 @@
 """Matrix utility functions for 3rd order force constants."""
 
-from typing import Optional
+from typing import Optional, Union
 
 import numpy as np
 import scipy
@@ -19,7 +19,7 @@ except ImportError:
     pass
 
 
-def _N3N3N3_to_NNNand333(combs: np.ndarray, N: int) -> np.ndarray:
+def _N3N3N3_to_NNNand333(combs: np.ndarray, N: int) -> tuple[np.ndarray, np.ndarray]:
     """Transform index order."""
     vecNNN, vec333 = np.divmod(combs[:, 0], 3)
     vecNNN *= N**2
@@ -35,10 +35,10 @@ def _N3N3N3_to_NNNand333(combs: np.ndarray, N: int) -> np.ndarray:
 
 def _construct_projector_permutation_lat_trans_from_combinations(
     combinations: np.ndarray,
-    permutations: np.ndarray,
+    permutations: Union[np.ndarray, list],
     atomic_decompr_idx: np.ndarray,
     trans_perms: np.ndarray,
-    included_indices: np.ndarray = None,
+    included_indices: Optional[np.ndarray] = None,
     n_perms_group: int = 1,
     use_mkl: bool = False,
     n_batch: int = 1,
@@ -73,16 +73,16 @@ def _construct_projector_permutation_lat_trans_from_combinations(
             if verbose:
                 print("Executed: proj_pt += c_pt.T @ c_pt", flush=True)
             if proj_pt is None:
-                proj_pt = dot_product_sparse(c_pt.T, c_pt, use_mkl=use_mkl)
+                proj_pt = dot_product_sparse(c_pt.T, c_pt, use_mkl=use_mkl)  # type: ignore
             else:
-                proj_pt += dot_product_sparse(c_pt.T, c_pt, use_mkl=use_mkl)
+                proj_pt += dot_product_sparse(c_pt.T, c_pt, use_mkl=use_mkl)  # type: ignore
             c_pt = None
 
     if c_pt is not None:
         if proj_pt is None:
-            proj_pt = dot_product_sparse(c_pt.T, c_pt, use_mkl=use_mkl)
+            proj_pt = dot_product_sparse(c_pt.T, c_pt, use_mkl=use_mkl)  # type: ignore
         else:
-            proj_pt += dot_product_sparse(c_pt.T, c_pt, use_mkl=use_mkl)
+            proj_pt += dot_product_sparse(c_pt.T, c_pt, use_mkl=use_mkl)  # type: ignore
     return proj_pt
 
 
@@ -289,7 +289,7 @@ def projector_permutation_lat_trans_O3(
         proj_pt += _projector_not_reduced(
             atomic_decompr_idx,
             trans_perms,
-            included_indices,
+            included_indices,  # type: ignore
             use_mkl=use_mkl,
         )
     return proj_pt
@@ -385,7 +385,7 @@ def compressed_projector_sum_rules_O3(
     NNN = natom**3
     NN = natom**2
 
-    proj_size = n_a_compress_mat.shape[1]
+    proj_size = n_a_compress_mat.shape[1]  # type: ignore
     proj_cplmt = csr_array((proj_size, proj_size), dtype="double")
 
     if atomic_decompr_idx is None:
@@ -510,7 +510,7 @@ def compressed_projector_sum_rules_O3_stable(
     NNN = natom**3
     NN = natom**2
 
-    proj_size = n_a_compress_mat.shape[1]
+    proj_size = n_a_compress_mat.shape[1]  # type: ignore
     proj_cplmt = csr_array((proj_size, proj_size), dtype="double")
 
     if atomic_decompr_idx is None:

--- a/src/symfc/utils/matrix_tools_O4.py
+++ b/src/symfc/utils/matrix_tools_O4.py
@@ -20,7 +20,7 @@ except ImportError:
     pass
 
 
-def N3N3N3N3_to_NNNNand3333(combs: np.ndarray, N: int) -> np.ndarray:
+def N3N3N3N3_to_NNNNand3333(combs: np.ndarray, N: int) -> tuple[np.ndarray, np.ndarray]:
     """Transform index order."""
     vecNNNN, vec3333 = np.divmod(combs[:, 0], 3)
     vecNNNN *= N**3
@@ -194,11 +194,11 @@ def projector_permutation_lat_trans_O4(
         if len(c_pt.data) > 2147483647 / 4:
             if verbose:
                 print("Executed: proj_pt += c_pt.T @ c_pt", flush=True)
-            proj_pt += dot_product_sparse(c_pt.T, c_pt, use_mkl=use_mkl)
+            proj_pt += dot_product_sparse(c_pt.T, c_pt, use_mkl=use_mkl)  # type: ignore
             c_pt = None
 
     if c_pt is not None:
-        proj_pt += dot_product_sparse(c_pt.T, c_pt, use_mkl=use_mkl)
+        proj_pt += dot_product_sparse(c_pt.T, c_pt, use_mkl=use_mkl)  # type: ignore
 
     """FC4 with four distinct indices (ia,jb,kc,ld)"""
     if verbose:
@@ -234,11 +234,11 @@ def projector_permutation_lat_trans_O4(
         if len(c_pt.data) > 2147483647 / 4:
             if verbose:
                 print("Executed: proj_pt += c_pt.T @ c_pt", flush=True)
-            proj_pt += dot_product_sparse(c_pt.T, c_pt, use_mkl=use_mkl)
+            proj_pt += dot_product_sparse(c_pt.T, c_pt, use_mkl=use_mkl)  # type: ignore
             c_pt = None
 
     if c_pt is not None:
-        proj_pt += dot_product_sparse(c_pt.T, c_pt, use_mkl=use_mkl)
+        proj_pt += dot_product_sparse(c_pt.T, c_pt, use_mkl=use_mkl)  # type: ignore
     return proj_pt
 
 
@@ -331,7 +331,7 @@ def compressed_projector_sum_rules_O4_stable(
     NNNN = natom**4
     NNN = natom**3
 
-    proj_size = n_a_compress_mat.shape[1]
+    proj_size = n_a_compress_mat.shape[1]  # type: ignore
     proj_cplmt = csr_array((proj_size, proj_size), dtype="double")
 
     if atomic_decompr_idx is None:
@@ -462,7 +462,7 @@ def compressed_projector_sum_rules_O4(
     NNNN = natom**4
     NNN = natom**3
 
-    proj_size = n_a_compress_mat.shape[1]
+    proj_size = n_a_compress_mat.shape[1]  # type: ignore
     proj_cplmt = csr_array((proj_size, proj_size), dtype="double")
 
     if atomic_decompr_idx is None:

--- a/src/symfc/utils/permutation_tools.py
+++ b/src/symfc/utils/permutation_tools.py
@@ -60,7 +60,7 @@ def get_combinations(
 
 
 def _eliminate_zero_elements(
-    perm_decompr_idx: np.ndarray, nonzero: np.array
+    perm_decompr_idx: np.ndarray, nonzero: np.ndarray
 ) -> np.ndarray:
     """Eliminate zero elements and reindex orbit indexes."""
     size_full = len(perm_decompr_idx)

--- a/src/symfc/utils/permutation_tools_O2.py
+++ b/src/symfc/utils/permutation_tools_O2.py
@@ -1,6 +1,6 @@
 """Permutation utility functions for 3rd order force constants."""
 
-from typing import Optional
+from typing import Optional, Union
 
 import numpy as np
 from scipy.sparse import csr_array
@@ -15,7 +15,7 @@ from symfc.utils.utils import get_indep_atoms_by_lat_trans
 from symfc.utils.utils_O2 import _get_atomic_lat_trans_decompr_indices
 
 
-def _N3N3_to_NNand33(combs: np.ndarray, N: int) -> np.ndarray:
+def _N3N3_to_NNand33(combs: np.ndarray, N: int) -> tuple[np.ndarray, np.ndarray]:
     """Transform index order."""
     vecNN, vec33 = np.divmod(combs[:, 0], 3)
     vecNN *= N
@@ -107,14 +107,14 @@ def compr_permutation_lat_trans_O2(
 
 def _update_perm_decompr_indices(
     combinations: np.ndarray,
-    permutations: np.ndarray,
+    permutations: Union[np.ndarray, list],
     atomic_decompr_idx: np.ndarray,
     trans_perms: np.ndarray,
     perm_decompr_idx: np.ndarray,
     n_perms_group: int = 1,
     n_batch: int = 1,
     verbose: bool = False,
-) -> csr_array:
+) -> np.ndarray:
     """Apply permutations to lattice translation basis.
 
     Return

--- a/src/symfc/utils/permutation_tools_O3.py
+++ b/src/symfc/utils/permutation_tools_O3.py
@@ -1,6 +1,6 @@
 """Permutation utility functions for 3rd order force constants."""
 
-from typing import Optional
+from typing import Optional, Union
 
 import numpy as np
 from scipy.sparse import csr_array
@@ -15,7 +15,7 @@ from symfc.utils.utils import get_indep_atoms_by_lat_trans
 from symfc.utils.utils_O3 import get_atomic_lat_trans_decompr_indices_O3
 
 
-def _N3N3N3_to_NNNand333(combs: np.ndarray, N: int) -> np.ndarray:
+def _N3N3N3_to_NNNand333(combs: np.ndarray, N: int) -> tuple[np.ndarray, np.ndarray]:
     """Transform index order."""
     vecNNN, vec333 = np.divmod(combs[:, 0], 3)
     vecNNN *= N**2
@@ -143,14 +143,14 @@ def compr_permutation_lat_trans_O3(
 
 def _update_perm_decompr_indices(
     combinations: np.ndarray,
-    permutations: np.ndarray,
+    permutations: Union[np.ndarray, list],
     atomic_decompr_idx: np.ndarray,
     trans_perms: np.ndarray,
     perm_decompr_idx: np.ndarray,
     n_perms_group: int = 1,
     n_batch: int = 1,
     verbose: bool = False,
-) -> csr_array:
+) -> np.ndarray:
     """Apply permutations to lattice translation basis.
 
     Return

--- a/src/symfc/utils/permutation_tools_O4.py
+++ b/src/symfc/utils/permutation_tools_O4.py
@@ -1,7 +1,7 @@
 """Permutation utility functions for 4th order force constants."""
 
 import itertools
-from typing import Optional
+from typing import Optional, Union
 
 import numpy as np
 from scipy.sparse import csr_array
@@ -16,7 +16,9 @@ from symfc.utils.utils import get_indep_atoms_by_lat_trans
 from symfc.utils.utils_O4 import get_atomic_lat_trans_decompr_indices_O4
 
 
-def _N3N3N3N3_to_NNNNand3333(combs: np.ndarray, N: int) -> np.ndarray:
+def _N3N3N3N3_to_NNNNand3333(
+    combs: np.ndarray, N: int
+) -> tuple[np.ndarray, np.ndarray]:
     """Transform index order."""
     vecNNNN, vec3333 = np.divmod(combs[:, 0], 3)
     vecNNNN *= N**3
@@ -198,14 +200,14 @@ def compr_permutation_lat_trans_O4(
 
 def _update_perm_decompr_indices(
     combinations: np.ndarray,
-    permutations: np.ndarray,
+    permutations: Union[np.ndarray, list],
     atomic_decompr_idx: np.ndarray,
     trans_perms: np.ndarray,
     perm_decompr_idx: np.ndarray,
     n_perms_group: int = 1,
     n_batch: int = 1,
     verbose: bool = False,
-) -> csr_array:
+) -> np.ndarray:
     """Apply permutations to lattice translation basis.
 
     Return

--- a/src/symfc/utils/rotation_tools_O2.py
+++ b/src/symfc/utils/rotation_tools_O2.py
@@ -3,6 +3,7 @@
 # from typing import Optional
 #
 import itertools
+from typing import Union
 
 import numpy as np
 from scipy.sparse import csr_array
@@ -46,7 +47,7 @@ def _orthogonalize_constraints(positions_cartesian: np.ndarray):
 def complementary_compr_projector_rot_sum_rules_O2(
     supercell: SymfcAtoms,
     trans_perms: np.ndarray,
-    n_a_compress_mat: np.ndarray,
+    n_a_compress_mat: Union[np.ndarray, csr_array],
     use_mkl: bool = False,
 ) -> csr_array:
     """Test function for setting rotational invariants."""

--- a/src/symfc/utils/utils_O2.py
+++ b/src/symfc/utils/utils_O2.py
@@ -283,20 +283,22 @@ def get_compr_coset_projector_O2(
     """Return compr matrix of sum of coset reps."""
     trans_perms = spg_reps.translation_permutations
     n_lp, N = trans_perms.shape
-    size = N**2 * 9 // n_lp if c_pt is None else c_pt.shape[1]
+    size = N**2 * 9 // n_lp if c_pt is None else c_pt.shape[1]  # type: ignore
     coset_reps_sum = csr_array((size, size), dtype="double")
 
     if atomic_decompr_idx is None:
-        atomic_decompr_idx = _get_atomic_lat_trans_decompr_indices(trans_perms)
+        _atomic_decompr_idx = _get_atomic_lat_trans_decompr_indices(trans_perms)
+    else:
+        _atomic_decompr_idx = atomic_decompr_idx
 
     if fc_cutoff is None:
         nonzero = None
         size_data = N**2
-        col = atomic_decompr_idx
+        col = _atomic_decompr_idx
     else:
         nonzero = fc_cutoff.nonzero_atomic_indices_fc2()
         size_data = np.count_nonzero(nonzero)
-        col = atomic_decompr_idx[nonzero]
+        col = _atomic_decompr_idx[nonzero]
 
     factor = 1 / n_lp / len(spg_reps.unique_rotation_indices)
     for i, _ in enumerate(spg_reps.unique_rotation_indices):
@@ -304,7 +306,7 @@ def get_compr_coset_projector_O2(
         mat = csr_array(
             (
                 np.ones(size_data, dtype="int_"),
-                (atomic_decompr_idx[permutation], col),
+                (_atomic_decompr_idx[permutation], col),  # type: ignore
             ),
             shape=(N**2 // n_lp, N**2 // n_lp),
             dtype="int_",

--- a/src/symfc/utils/utils_O3.py
+++ b/src/symfc/utils/utils_O3.py
@@ -149,7 +149,7 @@ def get_compr_coset_projector_O3(
     """Return compr matrix of sum of coset reps."""
     trans_perms = spg_reps.translation_permutations
     n_lp, N = trans_perms.shape
-    size = N**3 * 27 // n_lp if c_pt is None else c_pt.shape[1]
+    size = N**3 * 27 // n_lp if c_pt is None else c_pt.shape[1]  # type: ignore
 
     indep_atoms = get_indep_atoms_by_lat_trans(trans_perms)
     if atomic_decompr_idx is None:
@@ -198,7 +198,7 @@ def get_compr_coset_projector_O3(
             mat = dot_product_sparse(mat, c_pt, use_mkl=use_mkl)
 
         cosets[i % n_cosets] += mat
-    return sum(cosets)
+    return sum(cosets)  # type: ignore
 
 
 def get_compr_coset_projector_O3_stable(
@@ -212,7 +212,7 @@ def get_compr_coset_projector_O3_stable(
     """Return compr matrix of sum of coset reps."""
     trans_perms = spg_reps.translation_permutations
     n_lp, N = trans_perms.shape
-    size = N**3 * 27 // n_lp if c_pt is None else c_pt.shape[1]
+    size = N**3 * 27 // n_lp if c_pt is None else c_pt.shape[1]  # type: ignore
 
     if atomic_decompr_idx is None:
         atomic_decompr_idx = get_atomic_lat_trans_decompr_indices_O3(trans_perms)
@@ -256,4 +256,4 @@ def get_compr_coset_projector_O3_stable(
             mat = dot_product_sparse(mat, c_pt, use_mkl=use_mkl)
 
         cosets[i % n_cosets] += mat
-    return sum(cosets)
+    return sum(cosets)  # type: ignore

--- a/src/symfc/utils/utils_O4.py
+++ b/src/symfc/utils/utils_O4.py
@@ -153,7 +153,7 @@ def get_compr_coset_projector_O4(
     """Return compr projector of sum of coset reps."""
     trans_perms = spg_reps.translation_permutations
     n_lp, N = trans_perms.shape
-    size = N**4 * 81 // n_lp if c_pt is None else c_pt.shape[1]
+    size = N**4 * 81 // n_lp if c_pt is None else c_pt.shape[1]  # type: ignore
 
     indep_atoms = get_indep_atoms_by_lat_trans(trans_perms)
     if atomic_decompr_idx is None:
@@ -202,7 +202,7 @@ def get_compr_coset_projector_O4(
             mat = dot_product_sparse(mat, c_pt, use_mkl=use_mkl)
 
         cosets[i % n_cosets] += mat
-    return sum(cosets)
+    return sum(cosets)  # type: ignore
 
 
 def get_compr_coset_projector_O4_stable(
@@ -216,7 +216,7 @@ def get_compr_coset_projector_O4_stable(
     """Return compr projector of sum of coset reps."""
     trans_perms = spg_reps.translation_permutations
     n_lp, N = trans_perms.shape
-    size = N**4 * 81 // n_lp if c_pt is None else c_pt.shape[1]
+    size = N**4 * 81 // n_lp if c_pt is None else c_pt.shape[1]  # type: ignore
 
     if atomic_decompr_idx is None:
         atomic_decompr_idx = get_atomic_lat_trans_decompr_indices_O4(trans_perms)
@@ -260,4 +260,4 @@ def get_compr_coset_projector_O4_stable(
             mat = dot_product_sparse(mat, c_pt, use_mkl=use_mkl)
 
         cosets[i % n_cosets] += mat
-    return sum(cosets)
+    return sum(cosets)  # type: ignore


### PR DESCRIPTION
Using  PyLance's type checking mode `"python.analysis.typeCheckingMode": "basic"`, type hint errors were detected and fixed.