### PR TITLE
Add fc_cutoff attribute in FCBasisSetBase

### DIFF
--- a/src/symfc/api_symfc.py
+++ b/src/symfc/api_symfc.py
@@ -27,7 +27,7 @@ class Symfc:
         displacements: Optional[np.ndarray] = None,
         forces: Optional[np.ndarray] = None,
         spacegroup_operations: Optional[dict] = None,
-        cutoff: Optional[dict] = None,
+        cutoff: Optional[dict[int, float]] = None,
         use_mkl: bool = False,
         log_level: int = 0,
     ):
@@ -48,8 +48,9 @@ class Symfc:
             spglib is used. The following keys and values correspond to spglib
             symmetry dataset:
                 rotations : array_like translations : array_like
-        cutoff : dict, optional
+        cutoff : dict[int, float], optional
             Cutoff radii in angstrom for FC3 and FC4, by default None.
+            For example, {3: 4.0, 4: 4.0}
         use_mkl : bool, optional
             Use MKL library, by default False.
         log_level : int, optional

--- a/src/symfc/basis_sets/basis_sets_O1.py
+++ b/src/symfc/basis_sets/basis_sets_O1.py
@@ -92,6 +92,13 @@ class FCBasisSetO1(FCBasisSetBase):
         """Return compression matrix."""
         pass
 
+    @property
+    def atomic_decompr_idx(self) -> np.ndarray:
+        """Return atomic permutations by lattice translations."""
+        raise NotImplementedError(
+            "Atomic decompression indices are not defined for O1 basis sets."
+        )
+
     def run(self) -> FCBasisSetO1:
         """Compute compressed force constants basis set."""
         c_trans = self._get_c_trans()

--- a/src/symfc/basis_sets/basis_sets_O2.py
+++ b/src/symfc/basis_sets/basis_sets_O2.py
@@ -8,7 +8,6 @@ import numpy as np
 from scipy.sparse import csr_array
 
 from symfc.spg_reps import SpgRepsO2
-from symfc.utils.cutoff_tools import FCCutoff
 from symfc.utils.eig_tools import (
     dot_product_sparse,
     eigsh_projector,
@@ -78,15 +77,10 @@ class FCBasisSetO2(FCBasisSetBase):
             Log level. Default is 0.
 
         """
-        super().__init__(supercell, use_mkl=use_mkl, log_level=log_level)
+        super().__init__(supercell, cutoff=cutoff, use_mkl=use_mkl, log_level=log_level)
         self._spg_reps = SpgRepsO2(
             supercell, spacegroup_operations=spacegroup_operations
         )
-
-        if cutoff is None:
-            self._fc_cutoff = None
-        else:
-            self._fc_cutoff = FCCutoff(supercell, cutoff=cutoff)
 
         trans_perms = self._spg_reps.translation_permutations
         self._atomic_decompr_idx = _get_atomic_lat_trans_decompr_indices(trans_perms)

--- a/src/symfc/basis_sets/basis_sets_O3.py
+++ b/src/symfc/basis_sets/basis_sets_O3.py
@@ -9,7 +9,6 @@ import numpy as np
 from scipy.sparse import coo_array, csr_array
 
 from symfc.spg_reps import SpgRepsO3
-from symfc.utils.cutoff_tools import FCCutoff
 from symfc.utils.eig_tools import (
     dot_product_sparse,
     eigsh_projector,
@@ -83,15 +82,10 @@ class FCBasisSetO3(FCBasisSetBase):
             Log level. Default is 0.
 
         """
-        super().__init__(supercell, use_mkl=use_mkl, log_level=log_level)
+        super().__init__(supercell, cutoff=cutoff, use_mkl=use_mkl, log_level=log_level)
         self._spg_reps = SpgRepsO3(
             supercell, spacegroup_operations=spacegroup_operations
         )
-
-        if cutoff is None:
-            self._fc_cutoff = None
-        else:
-            self._fc_cutoff = FCCutoff(supercell, cutoff=cutoff)
 
         trans_perms = self._spg_reps.translation_permutations
         self._atomic_decompr_idx = get_atomic_lat_trans_decompr_indices_O3(trans_perms)

--- a/src/symfc/basis_sets/basis_sets_O4.py
+++ b/src/symfc/basis_sets/basis_sets_O4.py
@@ -9,7 +9,6 @@ import numpy as np
 from scipy.sparse import csr_array
 
 from symfc.spg_reps import SpgRepsO4
-from symfc.utils.cutoff_tools import FCCutoff
 from symfc.utils.eig_tools import (
     dot_product_sparse,
     eigsh_projector,
@@ -78,14 +77,10 @@ class FCBasisSetO4(FCBasisSetBase):
             Log level. Default is 0.
 
         """
-        super().__init__(supercell, use_mkl=use_mkl, log_level=log_level)
+        super().__init__(supercell, cutoff=cutoff, use_mkl=use_mkl, log_level=log_level)
         self._spg_reps = SpgRepsO4(
             supercell, spacegroup_operations=spacegroup_operations
         )
-        if cutoff is None:
-            self._fc_cutoff = None
-        else:
-            self._fc_cutoff = FCCutoff(supercell, cutoff=cutoff)
 
         trans_perms = self._spg_reps.translation_permutations
         self._atomic_decompr_idx = get_atomic_lat_trans_decompr_indices_O4(trans_perms)

--- a/src/symfc/basis_sets/basis_sets_base.py
+++ b/src/symfc/basis_sets/basis_sets_base.py
@@ -8,6 +8,7 @@ from typing import Optional
 import numpy as np
 
 from symfc.spg_reps import SpgRepsBase
+from symfc.utils.cutoff_tools import FCCutoff
 from symfc.utils.utils import SymfcAtoms
 
 
@@ -17,6 +18,7 @@ class FCBasisSetBase(ABC):
     def __init__(
         self,
         supercell: SymfcAtoms,
+        cutoff: Optional[float] = None,
         use_mkl: bool = False,
         log_level: int = 0,
     ):
@@ -26,6 +28,10 @@ class FCBasisSetBase(ABC):
         ----------
         supercell : SymfcAtoms
             Supercell.
+        cutoff: float
+            Cutoff distance in angstroms. Default is None.
+        use_mkl : bool
+            Use MKL or not. Default is False.
         log_level : int, optional
             Log level. Default is 0.
 
@@ -37,6 +43,11 @@ class FCBasisSetBase(ABC):
         self._spg_reps: SpgRepsBase
         self._atomic_decompr_idx: np.ndarray
         self._basis_set: np.ndarray
+
+        if cutoff is None:
+            self._fc_cutoff = None
+        else:
+            self._fc_cutoff = FCCutoff(supercell, cutoff=cutoff)
 
     @property
     @abstractmethod
@@ -79,6 +90,11 @@ class FCBasisSetBase(ABC):
         if self._spg_reps.p2s_map is None:
             raise ValueError("p2s_map is not set.")
         return self._spg_reps.p2s_map
+
+    @property
+    def fc_cutoff(self) -> Optional[FCCutoff]:
+        """Return force constants cutoff."""
+        return self._fc_cutoff
 
     @abstractmethod
     def run(self):


### PR DESCRIPTION
This PR aims to be able to access `FCCutoff` via `Symfc.basis_set`.