### PR TITLE
Add APIs for eigh and eigsh

### DIFF
--- a/src/symfc/__init__.py
+++ b/src/symfc/__init__.py
@@ -2,3 +2,5 @@
 
 from .api_symfc import Symfc  # noqa F401
 from .version import __version__  # noqa F401
+
+from .api_symfc import eigh, eigsh  # noqa F401

--- a/src/symfc/utils/eig_tools.py
+++ b/src/symfc/utils/eig_tools.py
@@ -209,7 +209,12 @@ def eigh_projector(
     return eigvecs[:, nonzero]
 
 
-def eigsh_projector(p: csr_array, verbose: bool = True) -> csr_array:
+def eigsh_projector(
+    p: csr_array,
+    atol: float = 1e-8,
+    rtol: float = 0.0,
+    verbose: bool = True,
+) -> csr_array:
     """Solve eigenvalue problem for matrix p.
 
     Return sparse matrix for eigenvectors of matrix p.
@@ -242,7 +247,7 @@ def eigsh_projector(p: csr_array, verbose: bool = True) -> csr_array:
                 uniq_eigvecs[key][1].append(block_label)
             except KeyError:
                 p_np = p_block.reshape((block_size, block_size))
-                eigvecs = eigh_projector(p_np, verbose=verbose)
+                eigvecs = eigh_projector(p_np, atol=atol, rtol=rtol, verbose=verbose)
                 uniq_eigvecs[key] = [eigvecs, [block_label]]
         else:
             if not np.isclose(p_block[0], 0.0):
@@ -257,7 +262,12 @@ def eigsh_projector(p: csr_array, verbose: bool = True) -> csr_array:
     return c_p
 
 
-def eigh_projector_submatrix_division(p_block: np.ndarray, verbose: bool = False):
+def eigh_projector_submatrix_division(
+    p_block: np.ndarray,
+    atol: float = 1e-8,
+    rtol: float = 0.0,
+    verbose: bool = False,
+):
     r"""Solve eigenvalue problem using submatrix division algorithm.
 
     This algorithm is optimized to solve an eigenvalue problem for
@@ -319,7 +329,7 @@ def eigh_projector_submatrix_division(p_block: np.ndarray, verbose: bool = False
             print("Solving complementary projector.", flush=True)
         cmplt = cmplt[:, :col_end_cmplt]
         p_block_rem = cmplt.T @ p_block @ cmplt
-        eigvecs = eigh_projector(p_block_rem, verbose=verbose)
+        eigvecs = eigh_projector(p_block_rem, atol=atol, rtol=rtol, verbose=verbose)
         eigvecs_shape1 = eigvecs.shape[1]  # type: ignore
         if verbose:
             print(eigvecs_shape1, "eigenvectors are found.", flush=True)
@@ -335,6 +345,8 @@ def eigh_projector_submatrix_division(p_block: np.ndarray, verbose: bool = False
 
 def eigsh_projector_sumrule(
     p: csr_array,
+    atol: float = 1e-8,
+    rtol: float = 0.0,
     size_threshold: int = 1000,
     verbose: bool = True,
 ) -> np.ndarray:
@@ -374,7 +386,7 @@ def eigsh_projector_sumrule(
         p_block = p[np.ix_(ids, ids)].toarray()
         rank = int(round(np.trace(p_block)))
         if rank > 0:
-            eigvecs = eigh(p_block, verbose=verbose)
+            eigvecs = eigh(p_block, atol=atol, rtol=rtol, verbose=verbose)
             if eigvecs is not None:
                 col_end = col_id + eigvecs.shape[1]  # type: ignore
                 eigvecs_full[ids, col_id:col_end] = eigvecs

--- a/tests/test_api_linalg.py
+++ b/tests/test_api_linalg.py
@@ -1,0 +1,42 @@
+"""Tests of API for eigh and eigsh."""
+
+import numpy as np
+import pytest
+from scipy.sparse import csr_array
+
+from symfc import eigh, eigsh
+
+
+def _assert_four_atoms_eigvecs(eigvecs: np.ndarray):
+    """Test eigenvectors of four-atom permutation projector."""
+    assert eigvecs.shape[1] == 3
+    assert np.linalg.norm(eigvecs[:, 0]) == pytest.approx(1.0)
+    assert np.linalg.norm(eigvecs[:, 1]) == pytest.approx(1.0)
+    assert np.linalg.norm(eigvecs[:, 2]) == pytest.approx(1.0)
+    assert eigvecs[:, 0] @ eigvecs[:, 1] == pytest.approx(0.0)
+    assert eigvecs[:, 1] @ eigvecs[:, 2] == pytest.approx(0.0)
+    assert eigvecs[:, 2] @ eigvecs[:, 0] == pytest.approx(0.0)
+
+    for i in range(3):
+        nonzero = np.where(np.abs(eigvecs[:, i]) > 1e-12)[0]
+        assert np.all(np.isclose(eigvecs[:, i][nonzero], eigvecs[nonzero[0], i]))
+
+
+def test_eigsh_and_eigh():
+    """Test eigsh."""
+    # Atomic permutations of four atoms
+    row = np.repeat(np.arange(12), 4)
+    col = np.array([i + j for j in range(3) for i in range(0, 12, 3)])
+    col = np.tile(col, 4)
+    data = np.full(len(col), 0.25)
+    proj = csr_array((data, (row, col)), shape=(12, 12), dtype=float)
+
+    eigvecs = eigsh(proj, log_level=0)
+    eigvecs = eigvecs.toarray()
+    _assert_four_atoms_eigvecs(eigvecs)
+
+    eigvecs = eigsh(proj, is_large_block=True, log_level=0)
+    _assert_four_atoms_eigvecs(eigvecs)
+
+    eigvecs = eigh(proj.toarray(), log_level=0)
+    _assert_four_atoms_eigvecs(eigvecs)


### PR DESCRIPTION
API functions for eigh_projector and eigsh_projector are added in api_symfc.py.
Eigenvalue solvers can be used for any projectors as follows.

from symfc import eigh, eigsh

proj = np.eye(12)
eigvecs = eigh(proj, log_level=1)

proj = scipy.sparse.identity(100).tocsr()
eigvecs = eigsh(proj, log_level=1)
eigvecs = eigsh(proj, log_level=1, is_large_block=True)
