### PR TITLE
Add mem-efficient blocked eigenvectors

### DIFF
--- a/src/symfc/api_symfc.py
+++ b/src/symfc/api_symfc.py
@@ -307,6 +307,7 @@ class Symfc:
         self,
         max_order: Optional[int] = None,
         orders: Optional[list] = None,
+        return_blocks: bool = False,
     ) -> Symfc:
         """Run basis set calculations.
 
@@ -325,7 +326,7 @@ class Symfc:
                     cutoff=self._cutoff[2],
                     use_mkl=self._use_mkl,
                     log_level=self._log_level,
-                ).run()
+                ).run(return_blocks=return_blocks)
                 self._basis_set[2] = basis_set_o2
             elif order == 3:
                 basis_set_o3 = FCBasisSetO3(
@@ -334,7 +335,7 @@ class Symfc:
                     cutoff=self._cutoff[3],
                     use_mkl=self._use_mkl,
                     log_level=self._log_level,
-                ).run()
+                ).run(return_blocks=return_blocks)
                 self._basis_set[3] = basis_set_o3
             elif order == 4:
                 basis_set_o4 = FCBasisSetO4(
@@ -343,7 +344,7 @@ class Symfc:
                     cutoff=self._cutoff[4],
                     use_mkl=self._use_mkl,
                     log_level=self._log_level,
-                ).run()
+                ).run(return_blocks=return_blocks)
                 self._basis_set[4] = basis_set_o4
         return self
 

--- a/src/symfc/basis_sets/basis_sets_O2.py
+++ b/src/symfc/basis_sets/basis_sets_O2.py
@@ -9,6 +9,7 @@ from scipy.sparse import csr_array
 
 from symfc.spg_reps import SpgRepsO2
 from symfc.utils.eig_tools import (
+    BlockedEigenvectors,
     dot_product_sparse,
     eigsh_projector,
     eigsh_projector_sumrule,
@@ -84,6 +85,7 @@ class FCBasisSetO2(FCBasisSetBase):
 
         self._n_a_compression_matrix: Optional[csr_array] = None
         self._basis_set: Optional[np.ndarray] = None
+        self._blocked_basis_set: Optional[BlockedEigenvectors] = None
 
     @property
     def compression_matrix(self) -> Optional[csr_array]:
@@ -116,7 +118,11 @@ class FCBasisSetO2(FCBasisSetBase):
         n_lp = self.translation_permutations.shape[0]
         return self._n_a_compression_matrix / np.sqrt(n_lp)
 
-    def run(self, rotational_sum_rules: bool = False) -> FCBasisSetO2:
+    def run(
+        self,
+        rotational_sum_rules: bool = False,
+        return_blocks: bool = False,
+    ) -> FCBasisSetO2:
         """Compute compressed force constants basis set."""
         trans_perms = self._spg_reps.translation_permutations
 
@@ -154,9 +160,16 @@ class FCBasisSetO2(FCBasisSetBase):
             )
             proj -= proj_rot_cmplt
 
-        eigvecs = eigsh_projector_sumrule(proj, verbose=self._log_level > 0)
+        eigvecs = eigsh_projector_sumrule(
+            proj,
+            return_blocks=return_blocks,
+            verbose=self._log_level > 0,
+        )
 
-        self._basis_set = eigvecs
+        if return_blocks:
+            self._blocked_basis_set = eigvecs
+        else:
+            self._basis_set = eigvecs
         self._n_a_compression_matrix = n_a_compress_mat
 
         return self

--- a/src/symfc/basis_sets/basis_sets_O3.py
+++ b/src/symfc/basis_sets/basis_sets_O3.py
@@ -10,6 +10,7 @@ from scipy.sparse import coo_array, csr_array
 
 from symfc.spg_reps import SpgRepsO3
 from symfc.utils.eig_tools import (
+    BlockedEigenvectors,
     dot_product_sparse,
     eigsh_projector,
     eigsh_projector_sumrule,
@@ -89,6 +90,7 @@ class FCBasisSetO3(FCBasisSetBase):
 
         self._n_a_compression_matrix: Optional[csr_array] = None
         self._basis_set: Optional[np.ndarray] = None
+        self._blocked_basis_set: Optional[BlockedEigenvectors] = None
 
     @property
     def compression_matrix(self) -> Optional[csr_array]:
@@ -123,7 +125,7 @@ class FCBasisSetO3(FCBasisSetBase):
         n_lp = self.translation_permutations.shape[0]
         return self._n_a_compression_matrix / np.sqrt(n_lp)
 
-    def run(self) -> FCBasisSetO3:
+    def run(self, return_blocks: bool = False) -> FCBasisSetO3:
         """Compute compressed force constants basis set."""
         trans_perms = self._spg_reps.translation_permutations
 
@@ -166,7 +168,11 @@ class FCBasisSetO3(FCBasisSetBase):
             verbose=self._log_level > 0,
         )
         tt6 = time.time()
-        eigvecs = eigsh_projector_sumrule(proj, verbose=self._log_level > 0)
+        eigvecs = eigsh_projector_sumrule(
+            proj,
+            return_blocks=return_blocks,
+            verbose=self._log_level > 0,
+        )
 
         if self._log_level:
             print("Final size of basis set:", eigvecs.shape, flush=True)
@@ -210,7 +216,10 @@ class FCBasisSetO3(FCBasisSetBase):
                 flush=True,
             )
 
-        self._basis_set = eigvecs
+        if return_blocks:
+            self._blocked_basis_set = eigvecs
+        else:
+            self._basis_set = eigvecs
         self._n_a_compression_matrix = n_a_compress_mat
 
         return self

--- a/src/symfc/basis_sets/basis_sets_O4.py
+++ b/src/symfc/basis_sets/basis_sets_O4.py
@@ -10,6 +10,7 @@ from scipy.sparse import csr_array
 
 from symfc.spg_reps import SpgRepsO4
 from symfc.utils.eig_tools import (
+    BlockedEigenvectors,
     dot_product_sparse,
     eigsh_projector,
     eigsh_projector_sumrule,
@@ -84,6 +85,7 @@ class FCBasisSetO4(FCBasisSetBase):
 
         self._n_a_compression_matrix: Optional[csr_array] = None
         self._basis_set: Optional[np.ndarray] = None
+        self._blocked_basis_set: Optional[BlockedEigenvectors] = None
 
     @property
     def compression_matrix(self) -> Optional[csr_array]:
@@ -118,7 +120,7 @@ class FCBasisSetO4(FCBasisSetBase):
         n_lp = self.translation_permutations.shape[0]
         return self._n_a_compression_matrix / np.sqrt(n_lp)
 
-    def run(self) -> FCBasisSetO4:
+    def run(self, return_blocks: bool = False) -> FCBasisSetO4:
         """Compute compressed force constants basis set."""
         trans_perms = self._spg_reps.translation_permutations
 
@@ -161,7 +163,11 @@ class FCBasisSetO4(FCBasisSetBase):
             verbose=self._log_level > 0,
         )
         tt6 = time.time()
-        eigvecs = eigsh_projector_sumrule(proj, verbose=self._log_level > 0)
+        eigvecs = eigsh_projector_sumrule(
+            proj,
+            return_blocks=return_blocks,
+            verbose=self._log_level > 0,
+        )
 
         if self._log_level:
             print("Final size of basis set:", eigvecs.shape, flush=True)
@@ -205,7 +211,10 @@ class FCBasisSetO4(FCBasisSetBase):
                 flush=True,
             )
 
-        self._basis_set = eigvecs
+        if return_blocks:
+            self._blocked_basis_set = eigvecs
+        else:
+            self._basis_set = eigvecs
         self._n_a_compression_matrix = n_a_compress_mat
 
         return self

--- a/src/symfc/basis_sets/basis_sets_base.py
+++ b/src/symfc/basis_sets/basis_sets_base.py
@@ -9,6 +9,7 @@ import numpy as np
 
 from symfc.spg_reps import SpgRepsBase
 from symfc.utils.cutoff_tools import FCCutoff
+from symfc.utils.eig_tools import BlockedEigenvectors
 from symfc.utils.utils import SymfcAtoms
 
 
@@ -43,6 +44,7 @@ class FCBasisSetBase(ABC):
         self._spg_reps: SpgRepsBase
         self._atomic_decompr_idx: np.ndarray
         self._basis_set: np.ndarray
+        self._blocked_basis_set: BlockedEigenvectors
 
         if cutoff is None:
             self._fc_cutoff = None
@@ -69,6 +71,11 @@ class FCBasisSetBase(ABC):
 
         """
         return self._basis_set
+
+    @property
+    def blocked_basis_set(self) -> Optional[BlockedEigenvectors]:
+        """Return compressed basis set in blocked format."""
+        return self._blocked_basis_set
 
     @property
     def atomic_decompr_idx(self) -> np.ndarray:

--- a/src/symfc/utils/eig_tools.py
+++ b/src/symfc/utils/eig_tools.py
@@ -389,7 +389,7 @@ class BlockedEigenvectors:
             dot_matrix[b.col_begin : b.col_end] = b.transpose_dot(mat)
         return dot_matrix
 
-    def reconver_full_eigenvectors(self):
+    def recover_full_eigenvectors(self):
         """Recover full blocked eigenvectors."""
         if self.eigvecs_full is None:
             self.eigvecs_full = np.zeros(self.shape, dtype="double")  # type: ignore

--- a/src/symfc/utils/eig_tools.py
+++ b/src/symfc/utils/eig_tools.py
@@ -343,11 +343,67 @@ def eigh_projector_submatrix_division(
     return eigvecs_block[:, :col_id]
 
 
+@dataclass
+class BlockedEigenvectorsComponent:
+    """Dataclass for each component of blocked eigenvectors."""
+
+    eigvecs: np.ndarray
+    rows: np.ndarray
+    col_begin: int
+    col_end: int
+
+    def dot(self, mat: np.ndarray):
+        """Dot product eigvecs @ mat."""
+        return self.eigvecs @ mat[self.col_begin : self.col_end]
+
+    def transpose_dot(self, mat: np.ndarray):
+        """Dot product eigvecs.T @ mat."""
+        return self.eigvecs.T @ mat[self.rows]
+
+
+@dataclass
+class BlockedEigenvectors:
+    """Dataclass for blocked eigenvectors."""
+
+    blocks: list[BlockedEigenvectorsComponent]
+    shape: tuple[int, int]
+    eigvecs_full: Optional[np.ndarray] = None
+
+    def dot(self, mat: np.ndarray):
+        """Dot product eigvecs @ mat."""
+        try:
+            dot_matrix = np.zeros((self.shape[0], mat.shape[1]))
+        except IndexError:
+            dot_matrix = np.zeros(self.shape[0])
+        for b in self.blocks:
+            dot_matrix[b.rows] = b.dot(mat)
+        return dot_matrix
+
+    def transpose_dot(self, mat: np.ndarray):
+        """Dot product eigvecs.T @ mat."""
+        try:
+            dot_matrix = np.zeros((self.shape[1], mat.shape[1]))
+        except IndexError:
+            dot_matrix = np.zeros(self.shape[1])
+        for b in self.blocks:
+            dot_matrix[b.col_begin : b.col_end] = b.transpose_dot(mat)
+        return dot_matrix
+
+    def reconver_full_eigenvectors(self):
+        """Recover full blocked eigenvectors."""
+        if self.eigvecs_full is None:
+            self.eigvecs_full = np.zeros(self.shape, dtype="double")  # type: ignore
+            for b in self.blocks:
+                self.eigvecs_full[b.rows, b.col_begin : b.col_end] = b.eigvecs
+        return self.eigvecs_full
+
+
 def eigsh_projector_sumrule(
     p: csr_array,
     atol: float = 1e-8,
     rtol: float = 0.0,
     size_threshold: int = 1000,
+    return_blocks: bool = False,
     verbose: bool = True,
 ) -> np.ndarray:
     """Solve eigenvalue problem for matrix p.
@@ -376,19 +432,45 @@ def eigsh_projector_sumrule(
     if verbose:
         print("Number of blocks in projector (Sum rule):", len(group), flush=True)
 
-    eigvecs_full = np.zeros(p.shape, dtype="double")  # type: ignore
-    col_id = 0
-    for i, ids in enumerate(group.values()):
-        if verbose and len(ids) > 2:
-            print("Eigsh_solver_block:", i + 1, "/", len(group), flush=True)
-            print(" - Block_size:", len(ids), flush=True)
-        ids = np.array(ids)
-        p_block = p[np.ix_(ids, ids)].toarray()
-        rank = int(round(np.trace(p_block)))
-        if rank > 0:
-            eigvecs = eigh(p_block, atol=atol, rtol=rtol, verbose=verbose)
-            if eigvecs is not None:
-                col_end = col_id + eigvecs.shape[1]  # type: ignore
-                eigvecs_full[ids, col_id:col_end] = eigvecs
-                col_id = col_end
-    return eigvecs_full[:, :col_id]
+    if return_blocks:
+        col_id = 0
+        eigvecs_blocks = []
+        for i, ids in enumerate(group.values()):
+            if verbose and len(ids) > 2:
+                print("Eigsh_solver_block:", i + 1, "/", len(group), flush=True)
+                print(" - Block_size:", len(ids), flush=True)
+            ids = np.array(ids)
+            p_block = p[np.ix_(ids, ids)].toarray()
+            rank = int(round(np.trace(p_block)))
+            if rank > 0:
+                eigvecs = eigh(p_block, atol=atol, rtol=rtol, verbose=verbose)
+                if eigvecs is not None:
+                    col_end = col_id + eigvecs.shape[1]  # type: ignore
+                    block = BlockedEigenvectorsComponent(
+                        eigvecs=eigvecs,
+                        rows=ids,
+                        col_begin=col_id,
+                        col_end=col_end,
+                    )
+                    eigvecs_blocks.append(block)
+                    col_id = col_end
+
+        blocks = BlockedEigenvectors(blocks=eigvecs_blocks, shape=(p.shape[0], col_id))
+        return blocks
+    else:
+        eigvecs_full = np.zeros(p.shape, dtype="double")  # type: ignore
+        col_id = 0
+        for i, ids in enumerate(group.values()):
+            if verbose and len(ids) > 2:
+                print("Eigsh_solver_block:", i + 1, "/", len(group), flush=True)
+                print(" - Block_size:", len(ids), flush=True)
+            ids = np.array(ids)
+            p_block = p[np.ix_(ids, ids)].toarray()
+            rank = int(round(np.trace(p_block)))
+            if rank > 0:
+                eigvecs = eigh(p_block, atol=atol, rtol=rtol, verbose=verbose)
+                if eigvecs is not None:
+                    col_end = col_id + eigvecs.shape[1]  # type: ignore
+                    eigvecs_full[ids, col_id:col_end] = eigvecs
+                    col_id = col_end
+        return eigvecs_full[:, :col_id]


### PR DESCRIPTION
Option return_blocks is added to get memory-efficient blocked eigenvectors .

Dot products of blocked eigenvectors and a vector (a matrix) can be calculated as follows.

symfc = Symfc(supercell, use_mkl=True, log_level=1, cutoff=None)
symfc.compute_basis_set(max_order=3, return_blocks=True)

for order in [2, 3]:
    blocks = symfc.basis_set[order].blocked_basis_set
    x1 = np.ones(blocks.shape[1])
    vec1 = blocks.dot(x1)    # vec1 = blocked_eigvecs @ x1
    x2 = np.ones(blocks.shape[0])
    vec2 = blocks.transpose_dot(x2) # vec2 = blocked_eigvecs.T @ x2
 