### PR TITLE
Implement solvers using blocked basis set.

### DIFF
--- a/src/symfc/api_symfc.py
+++ b/src/symfc/api_symfc.py
@@ -162,7 +162,9 @@ class Symfc:
             Batch size in solvers, by default 100.
         """
         if self._displacements is not None and self._forces is not None:
-            self.compute_basis_set(max_order=max_order, orders=orders)
+            self.compute_basis_set(
+                max_order=max_order, orders=orders, return_blocks=True
+            )
             self.solve(
                 max_order=max_order,
                 orders=orders,

--- a/src/symfc/api_symfc.py
+++ b/src/symfc/api_symfc.py
@@ -162,9 +162,7 @@ class Symfc:
             Batch size in solvers, by default 100.
         """
         if self._displacements is not None and self._forces is not None:
-            self.compute_basis_set(
-                max_order=max_order, orders=orders, return_blocks=True
-            )
+            self.compute_basis_set(max_order=max_order, orders=orders)
             self.solve(
                 max_order=max_order,
                 orders=orders,
@@ -309,7 +307,6 @@ class Symfc:
         self,
         max_order: Optional[int] = None,
         orders: Optional[list] = None,
-        return_blocks: bool = False,
     ) -> Symfc:
         """Run basis set calculations.
 
@@ -328,7 +325,7 @@ class Symfc:
                     cutoff=self._cutoff[2],
                     use_mkl=self._use_mkl,
                     log_level=self._log_level,
-                ).run(return_blocks=return_blocks)
+                ).run()
                 self._basis_set[2] = basis_set_o2
             elif order == 3:
                 basis_set_o3 = FCBasisSetO3(
@@ -337,7 +334,7 @@ class Symfc:
                     cutoff=self._cutoff[3],
                     use_mkl=self._use_mkl,
                     log_level=self._log_level,
-                ).run(return_blocks=return_blocks)
+                ).run()
                 self._basis_set[3] = basis_set_o3
             elif order == 4:
                 basis_set_o4 = FCBasisSetO4(
@@ -346,7 +343,7 @@ class Symfc:
                     cutoff=self._cutoff[4],
                     use_mkl=self._use_mkl,
                     log_level=self._log_level,
-                ).run(return_blocks=return_blocks)
+                ).run()
                 self._basis_set[4] = basis_set_o4
         return self
 

--- a/src/symfc/basis_sets/basis_sets_O2.py
+++ b/src/symfc/basis_sets/basis_sets_O2.py
@@ -9,7 +9,7 @@ from scipy.sparse import csr_array
 
 from symfc.spg_reps import SpgRepsO2
 from symfc.utils.eig_tools import (
-    BlockedEigenvectors,
+    BlockedMatrix,
     dot_product_sparse,
     eigsh_projector,
     eigsh_projector_sumrule,
@@ -85,7 +85,7 @@ class FCBasisSetO2(FCBasisSetBase):
 
         self._n_a_compression_matrix: Optional[csr_array] = None
         self._basis_set: Optional[np.ndarray] = None
-        self._blocked_basis_set: Optional[BlockedEigenvectors] = None
+        self._blocked_basis_set: Optional[BlockedMatrix] = None
 
     @property
     def compression_matrix(self) -> Optional[csr_array]:
@@ -118,11 +118,7 @@ class FCBasisSetO2(FCBasisSetBase):
         n_lp = self.translation_permutations.shape[0]
         return self._n_a_compression_matrix / np.sqrt(n_lp)
 
-    def run(
-        self,
-        rotational_sum_rules: bool = False,
-        return_blocks: bool = False,
-    ) -> FCBasisSetO2:
+    def run(self, rotational_sum_rules: bool = False) -> FCBasisSetO2:
         """Compute compressed force constants basis set."""
         trans_perms = self._spg_reps.translation_permutations
 
@@ -160,16 +156,9 @@ class FCBasisSetO2(FCBasisSetBase):
             )
             proj -= proj_rot_cmplt
 
-        eigvecs = eigsh_projector_sumrule(
-            proj,
-            return_blocks=return_blocks,
-            verbose=self._log_level > 0,
-        )
+        eigvecs = eigsh_projector_sumrule(proj, verbose=self._log_level > 0)
 
-        if return_blocks:
-            self._blocked_basis_set = eigvecs
-        else:
-            self._basis_set = eigvecs
+        self._blocked_basis_set = eigvecs
         self._n_a_compression_matrix = n_a_compress_mat
 
         return self

--- a/src/symfc/basis_sets/basis_sets_O3.py
+++ b/src/symfc/basis_sets/basis_sets_O3.py
@@ -10,7 +10,7 @@ from scipy.sparse import coo_array, csr_array
 
 from symfc.spg_reps import SpgRepsO3
 from symfc.utils.eig_tools import (
-    BlockedEigenvectors,
+    BlockedMatrix,
     dot_product_sparse,
     eigsh_projector,
     eigsh_projector_sumrule,
@@ -90,7 +90,7 @@ class FCBasisSetO3(FCBasisSetBase):
 
         self._n_a_compression_matrix: Optional[csr_array] = None
         self._basis_set: Optional[np.ndarray] = None
-        self._blocked_basis_set: Optional[BlockedEigenvectors] = None
+        self._blocked_basis_set: Optional[BlockedMatrix] = None
 
     @property
     def compression_matrix(self) -> Optional[csr_array]:
@@ -125,7 +125,7 @@ class FCBasisSetO3(FCBasisSetBase):
         n_lp = self.translation_permutations.shape[0]
         return self._n_a_compression_matrix / np.sqrt(n_lp)
 
-    def run(self, return_blocks: bool = False) -> FCBasisSetO3:
+    def run(self) -> FCBasisSetO3:
         """Compute compressed force constants basis set."""
         trans_perms = self._spg_reps.translation_permutations
 
@@ -168,11 +168,7 @@ class FCBasisSetO3(FCBasisSetBase):
             verbose=self._log_level > 0,
         )
         tt6 = time.time()
-        eigvecs = eigsh_projector_sumrule(
-            proj,
-            return_blocks=return_blocks,
-            verbose=self._log_level > 0,
-        )
+        eigvecs = eigsh_projector_sumrule(proj, verbose=self._log_level > 0)
 
         if self._log_level:
             print("Final size of basis set:", eigvecs.shape, flush=True)
@@ -216,10 +212,7 @@ class FCBasisSetO3(FCBasisSetBase):
                 flush=True,
             )
 
-        if return_blocks:
-            self._blocked_basis_set = eigvecs
-        else:
-            self._basis_set = eigvecs
+        self._blocked_basis_set = eigvecs
         self._n_a_compression_matrix = n_a_compress_mat
 
         return self

--- a/src/symfc/basis_sets/basis_sets_O4.py
+++ b/src/symfc/basis_sets/basis_sets_O4.py
@@ -10,7 +10,7 @@ from scipy.sparse import csr_array
 
 from symfc.spg_reps import SpgRepsO4
 from symfc.utils.eig_tools import (
-    BlockedEigenvectors,
+    BlockedMatrix,
     dot_product_sparse,
     eigsh_projector,
     eigsh_projector_sumrule,
@@ -85,7 +85,7 @@ class FCBasisSetO4(FCBasisSetBase):
 
         self._n_a_compression_matrix: Optional[csr_array] = None
         self._basis_set: Optional[np.ndarray] = None
-        self._blocked_basis_set: Optional[BlockedEigenvectors] = None
+        self._blocked_basis_set: Optional[BlockedMatrix] = None
 
     @property
     def compression_matrix(self) -> Optional[csr_array]:
@@ -120,7 +120,7 @@ class FCBasisSetO4(FCBasisSetBase):
         n_lp = self.translation_permutations.shape[0]
         return self._n_a_compression_matrix / np.sqrt(n_lp)
 
-    def run(self, return_blocks: bool = False) -> FCBasisSetO4:
+    def run(self) -> FCBasisSetO4:
         """Compute compressed force constants basis set."""
         trans_perms = self._spg_reps.translation_permutations
 
@@ -163,11 +163,7 @@ class FCBasisSetO4(FCBasisSetBase):
             verbose=self._log_level > 0,
         )
         tt6 = time.time()
-        eigvecs = eigsh_projector_sumrule(
-            proj,
-            return_blocks=return_blocks,
-            verbose=self._log_level > 0,
-        )
+        eigvecs = eigsh_projector_sumrule(proj, verbose=self._log_level > 0)
 
         if self._log_level:
             print("Final size of basis set:", eigvecs.shape, flush=True)
@@ -211,10 +207,7 @@ class FCBasisSetO4(FCBasisSetBase):
                 flush=True,
             )
 
-        if return_blocks:
-            self._blocked_basis_set = eigvecs
-        else:
-            self._basis_set = eigvecs
+        self._blocked_basis_set = eigvecs
         self._n_a_compression_matrix = n_a_compress_mat
 
         return self

--- a/src/symfc/basis_sets/basis_sets_base.py
+++ b/src/symfc/basis_sets/basis_sets_base.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from symfc.spg_reps import SpgRepsBase
 from symfc.utils.cutoff_tools import FCCutoff
-from symfc.utils.eig_tools import BlockedEigenvectors
+from symfc.utils.eig_tools import BlockedMatrix
 from symfc.utils.utils import SymfcAtoms
 
 
@@ -44,7 +44,7 @@ class FCBasisSetBase(ABC):
         self._spg_reps: SpgRepsBase
         self._atomic_decompr_idx: np.ndarray
         self._basis_set: np.ndarray
-        self._blocked_basis_set: BlockedEigenvectors
+        self._blocked_basis_set: BlockedMatrix
 
         if cutoff is None:
             self._fc_cutoff = None
@@ -70,10 +70,10 @@ class FCBasisSetBase(ABC):
         shape=(n_c, n_bases), dtype='double'.
 
         """
-        return self._basis_set
+        return self._blocked_basis_set.recover_full_matrix()
 
     @property
-    def blocked_basis_set(self) -> Optional[BlockedEigenvectors]:
+    def blocked_basis_set(self) -> Optional[BlockedMatrix]:
         """Return compressed basis set in blocked format."""
         return self._blocked_basis_set
 

--- a/src/symfc/solvers/solver_O2.py
+++ b/src/symfc/solvers/solver_O2.py
@@ -56,7 +56,7 @@ class FCSolverO2(FCSolverBase):
 
         fc2_basis = self._basis_set
         compress_mat_fc2 = fc2_basis.compact_compression_matrix
-        basis_set_fc2 = fc2_basis.basis_set
+        basis_set_fc2 = fc2_basis.blocked_basis_set
 
         atomic_decompr_idx_fc2 = fc2_basis.atomic_decompr_idx
 
@@ -112,7 +112,7 @@ class FCSolverO2(FCSolverBase):
             raise ValueError("Invalid comp_mat_type.")
 
         N = self._natom
-        fc2 = fc2_basis.basis_set @ self._coefs
+        fc2 = fc2_basis.blocked_basis_set.dot(self._coefs)
         fc2 = np.array(
             (comp_mat_fc2 @ fc2).reshape((-1, N, 3, 3)), dtype="double", order="C"
         )
@@ -227,9 +227,9 @@ def prepare_normal_equation_O2(
 
     if verbose:
         print("Solver:", "Calculate X.T @ X and X.T @ y", flush=True)
-    mat22 = mat22 @ compress_eigvecs_fc2
-    XTX = compress_eigvecs_fc2.T @ mat22
-    XTy = compress_eigvecs_fc2.T @ mat2y
+    mat22 = compress_eigvecs_fc2.dot(mat22, left=True)
+    XTX = compress_eigvecs_fc2.transpose_dot(mat22)
+    XTy = compress_eigvecs_fc2.transpose_dot(mat2y)
 
     compact_compress_mat_fc2 /= const_fc2
     t_all2 = time.time()

--- a/src/symfc/solvers/solver_O3.py
+++ b/src/symfc/solvers/solver_O3.py
@@ -60,7 +60,7 @@ class FCSolverO3(FCSolverBase):
 
         fc3_basis = self._basis_set
         compress_mat_fc3 = fc3_basis.compact_compression_matrix
-        basis_set_fc3 = fc3_basis.basis_set
+        basis_set_fc3 = fc3_basis.blocked_basis_set
 
         atomic_decompr_idx_fc3 = fc3_basis.atomic_decompr_idx
 
@@ -116,7 +116,7 @@ class FCSolverO3(FCSolverBase):
             raise ValueError("Invalid comp_mat_type.")
 
         N = self._natom
-        fc3 = fc3_basis.basis_set @ self._coefs
+        fc3 = fc3_basis.blocked_basis_set.dot(self._coefs)
         fc3 = np.array(
             (comp_mat_fc3 @ fc3).reshape((-1, N, N, 3, 3, 3)),
             dtype="double",
@@ -207,8 +207,11 @@ def prepare_normal_equation_O3(
 
     if verbose:
         print("Solver:", "Calculate X.T @ X and X.T @ y", flush=True)
-    XTX = compress_eigvecs_fc3.T @ mat33 @ compress_eigvecs_fc3
-    XTy = compress_eigvecs_fc3.T @ mat3y
+    XTX = compress_eigvecs_fc3.dot(compress_eigvecs_fc3.transpose_dot(mat33), left=True)
+    XTy = compress_eigvecs_fc3.transpose_dot(mat3y)
+
+    # XTX = compress_eigvecs_fc3.T @ mat33 @ compress_eigvecs_fc3
+    # XTy = compress_eigvecs_fc3.T @ mat3y
 
     compact_compress_mat_fc3 /= const_fc3
     t_all2 = time.time()

--- a/src/symfc/solvers/solver_O4.py
+++ b/src/symfc/solvers/solver_O4.py
@@ -63,7 +63,7 @@ class FCSolverO4(FCSolverBase):
 
         fc4_basis = self._basis_set
         compress_mat_fc4 = fc4_basis.compact_compression_matrix
-        basis_set_fc4 = fc4_basis.basis_set
+        basis_set_fc4 = fc4_basis.blocked_basis_set
 
         atomic_decompr_idx_fc4 = fc4_basis.atomic_decompr_idx
 
@@ -119,7 +119,7 @@ class FCSolverO4(FCSolverBase):
             raise ValueError("Invalid comp_mat_type.")
 
         N = self._natom
-        fc4 = fc4_basis.basis_set @ self._coefs
+        fc4 = fc4_basis.blocked_basis_set.dot(self._coefs)
         fc4 = np.array(
             (comp_mat_fc4 @ fc4).reshape((-1, N, N, N, 3, 3, 3, 3)),
             dtype="double",
@@ -211,8 +211,11 @@ def prepare_normal_equation_O4(
 
     if verbose:
         print("Solver:", "Calculate X.T @ X and X.T @ y", flush=True)
-    XTX = compress_eigvecs_fc4.T @ mat44 @ compress_eigvecs_fc4
-    XTy = compress_eigvecs_fc4.T @ mat4y
+
+    XTX = compress_eigvecs_fc4.dot(compress_eigvecs_fc4.transpose_dot(mat44), left=True)
+    XTy = compress_eigvecs_fc4.transpose_dot(mat4y)
+    # XTX = compress_eigvecs_fc4.T @ mat44 @ compress_eigvecs_fc4
+    # XTy = compress_eigvecs_fc4.T @ mat4y
 
     compact_compress_mat_fc4 /= const_fc4
     t_all2 = time.time()

--- a/src/symfc/utils/eig_tools.py
+++ b/src/symfc/utils/eig_tools.py
@@ -294,7 +294,7 @@ def eigh_projector_submatrix_division(
     # cmplt = np.zeros((p_block.shape[0], p_block.shape[0] // 2), dtype="double")
 
     p_size = p_block.shape[0]
-    target_size = min(max(p_size // 10, 1000), 10000)
+    target_size = min(max(p_size // 10, 1000), 20000)
 
     col_id, col_id_cmplt = 0, 0
     for begin, end in zip(*get_batch_slice(p_size, target_size)):

--- a/src/symfc/utils/eig_tools.py
+++ b/src/symfc/utils/eig_tools.py
@@ -445,7 +445,7 @@ def eigsh_projector_sumrule(
     rtol: float = 0.0,
     size_threshold: int = 1000,
     verbose: bool = True,
-) -> np.ndarray:
+) -> BlockedMatrix:
     """Solve eigenvalue problem for matrix p.
 
     Return dense matrix for eigenvectors of matrix p.

--- a/src/symfc/utils/eig_tools.py
+++ b/src/symfc/utils/eig_tools.py
@@ -294,7 +294,7 @@ def eigh_projector_submatrix_division(
     # cmplt = np.zeros((p_block.shape[0], p_block.shape[0] // 2), dtype="double")
 
     p_size = p_block.shape[0]
-    target_size = min(max(p_size // 10, 1000), 3000)
+    target_size = min(max(p_size // 10, 1000), 10000)
 
     col_id, col_id_cmplt = 0, 0
     for begin, end in zip(*get_batch_slice(p_size, target_size)):

--- a/tests/test_api_linalg.py
+++ b/tests/test_api_linalg.py
@@ -36,6 +36,7 @@ def test_eigsh_and_eigh():
     _assert_four_atoms_eigvecs(eigvecs)
 
     eigvecs = eigsh(proj, is_large_block=True, log_level=0)
+    eigvecs = eigvecs.recover_full_matrix()
     _assert_four_atoms_eigvecs(eigvecs)
 
     eigvecs = eigh(proj.toarray(), log_level=0)

--- a/tests/utils/test_eig_tools.py
+++ b/tests/utils/test_eig_tools.py
@@ -36,6 +36,7 @@ def test_eigsh_projector():
         assert np.all(np.isclose(eigvecs[:, i][nonzero], eigvecs[nonzero[0], i]))
 
     eigvecs = eigsh_projector_sumrule(proj, verbose=False)
+    eigvecs = eigvecs.recover_full_matrix()
 
     assert eigvecs.shape[1] == 3
     assert np.linalg.norm(eigvecs[:, 0]) == pytest.approx(1.0)


### PR DESCRIPTION
Solvers have been revised using blocked basis set. Required memory is reduced in large systems.

The size of submatrix division has been changed in eigh_projector_submatrix_division to accelerate solving eigenvalue problems for large projection matrices.