### PR TITLE
Correct link to PyPI

### DIFF
--- a/doc/install.md
+++ b/doc/install.md
@@ -2,7 +2,7 @@
 
 PyPI and conda-forge packages are available.
 
-- https://pypi.org/project/sympy/
+- https://pypi.org/project/symfc
 - https://anaconda.org/conda-forge/symfc
 
 ## Requirement


### PR DESCRIPTION
Just noticed this when looking into an [issue in phonopy](https://github.com/phonopy/phonopy/issues/598)