### PR TITLE
Reduce required memory in compress_matrix

### DIFF
--- a/src/symfc/utils/solver_funcs.py
+++ b/src/symfc/utils/solver_funcs.py
@@ -34,6 +34,10 @@ def get_batch_slice(n_data: int, batch_size: int):
     begin_batch = list(range(0, n_data, batch_size))
     if len(begin_batch) > 1:
         end_batch = list(begin_batch[1:]) + [n_data]
+        if (end_batch[-1] - end_batch[-2]) < batch_size // 5:
+            end_batch[-2] = end_batch[-1]
+            begin_batch = begin_batch[:-1]
+            end_batch = end_batch[:-1]
     else:
         end_batch = [n_data]
     return begin_batch, end_batch

--- a/tests/utils/test_block.py
+++ b/tests/utils/test_block.py
@@ -1,6 +1,7 @@
 """Tests of block matrix functions."""
 
 import numpy as np
+from scipy.sparse import csr_array
 
 from symfc.utils.matrix import BlockMatrix, BlockMatrixComponent
 
@@ -51,3 +52,7 @@ def test_block_matrix():
 
     mat3 = np.array([[3, 1, 4, 3], [5, 7, 3, 1], [2, 8, 7, 4], [5, 9, 0, 2]])
     np.testing.assert_array_equal(bm.compress_matrix(mat3), mat.T @ mat3 @ mat)
+    np.testing.assert_array_equal(
+        bm.compress_csr_matrix(csr_array(mat3)),
+        mat.T @ mat3 @ mat,
+    )


### PR DESCRIPTION
This PR aims to reduce required memory in solving large projection matrices for translational sum rules.

- Compression of CSR matrix in `BlockMatrix`, block.T @ projector @ block, becomes more efficient.
- Block division algorithm and block size parameters have been tuned for large projectors in addition to small ones.
- A test for `BlockMatrix` has been added.

But mp-27209 requires a huge amount of memory ...