### PR TITLE
Use complementary matrix as compression matrix

### DIFF
--- a/src/symfc/solvers/solver_O2.py
+++ b/src/symfc/solvers/solver_O2.py
@@ -232,8 +232,7 @@ def prepare_normal_equation_O2(
 
     if verbose:
         print("Solver:", "Calculate X.T @ X and X.T @ y", flush=True)
-    mat22 = block_matrix_sandwich(compress_eigvecs_fc2, compress_eigvecs_fc2, mat22)
-    XTX = compress_eigvecs_fc2.transpose_dot(mat22)
+    XTX = block_matrix_sandwich(compress_eigvecs_fc2, compress_eigvecs_fc2, mat22)
     XTy = compress_eigvecs_fc2.transpose_dot(mat2y)
 
     compact_compress_mat_fc2 /= const_fc2

--- a/src/symfc/solvers/solver_O2.py
+++ b/src/symfc/solvers/solver_O2.py
@@ -9,6 +9,7 @@ import numpy as np
 from scipy.sparse import csr_array
 
 from symfc.basis_sets import FCBasisSetO2
+from symfc.utils.matrix import block_matrix_sandwich
 from symfc.utils.solver_funcs import get_batch_slice, solve_linear_equation
 
 try:
@@ -231,7 +232,7 @@ def prepare_normal_equation_O2(
 
     if verbose:
         print("Solver:", "Calculate X.T @ X and X.T @ y", flush=True)
-    mat22 = compress_eigvecs_fc2.dot(mat22, left=True)
+    mat22 = block_matrix_sandwich(compress_eigvecs_fc2, compress_eigvecs_fc2, mat22)
     XTX = compress_eigvecs_fc2.transpose_dot(mat22)
     XTy = compress_eigvecs_fc2.transpose_dot(mat2y)
 

--- a/src/symfc/solvers/solver_O2O3.py
+++ b/src/symfc/solvers/solver_O2O3.py
@@ -11,7 +11,7 @@ from scipy.sparse import csr_array
 
 from symfc.basis_sets import FCBasisSetO2, FCBasisSetO3
 from symfc.solvers.solver_O2 import reshape_nN33_nx_to_N3_n3nx
-from symfc.utils.matrix import BlockMatrix
+from symfc.utils.matrix import BlockMatrix, block_matrix_sandwich
 from symfc.utils.solver_funcs import get_batch_slice, solve_linear_equation
 
 try:
@@ -346,15 +346,9 @@ def prepare_normal_equation_O2O3(
     if verbose:
         print("Solver:", "Calculate X.T @ X and X.T @ y", flush=True)
 
-    mat22 = compress_eigvecs_fc2.dot(
-        compress_eigvecs_fc2.transpose_dot(mat22), left=True
-    )
-    mat23 = compress_eigvecs_fc3.dot(
-        compress_eigvecs_fc2.transpose_dot(mat23), left=True
-    )
-    mat33 = compress_eigvecs_fc3.dot(
-        compress_eigvecs_fc3.transpose_dot(mat33), left=True
-    )
+    mat22 = block_matrix_sandwich(compress_eigvecs_fc2, compress_eigvecs_fc2, mat22)
+    mat23 = block_matrix_sandwich(compress_eigvecs_fc2, compress_eigvecs_fc3, mat23)
+    mat33 = block_matrix_sandwich(compress_eigvecs_fc3, compress_eigvecs_fc3, mat33)
     mat2y = compress_eigvecs_fc2.transpose_dot(mat2y)
     mat3y = compress_eigvecs_fc3.transpose_dot(mat3y)
 

--- a/src/symfc/solvers/solver_O3.py
+++ b/src/symfc/solvers/solver_O3.py
@@ -9,6 +9,7 @@ import numpy as np
 
 from symfc.basis_sets import FCBasisSetO3
 from symfc.solvers.solver_O2O3 import reshape_nNN333_nx_to_N3N3_n3nx, set_disps_N3N3
+from symfc.utils.matrix import block_matrix_sandwich
 from symfc.utils.solver_funcs import get_batch_slice, solve_linear_equation
 
 try:
@@ -211,11 +212,9 @@ def prepare_normal_equation_O3(
 
     if verbose:
         print("Solver:", "Calculate X.T @ X and X.T @ y", flush=True)
-    XTX = compress_eigvecs_fc3.dot(compress_eigvecs_fc3.transpose_dot(mat33), left=True)
-    XTy = compress_eigvecs_fc3.transpose_dot(mat3y)
 
-    # XTX = compress_eigvecs_fc3.T @ mat33 @ compress_eigvecs_fc3
-    # XTy = compress_eigvecs_fc3.T @ mat3y
+    XTX = block_matrix_sandwich(compress_eigvecs_fc3, compress_eigvecs_fc3, mat33)
+    XTy = compress_eigvecs_fc3.transpose_dot(mat3y)
 
     compact_compress_mat_fc3 /= const_fc3
     t_all2 = time.time()

--- a/src/symfc/solvers/solver_O3O4.py
+++ b/src/symfc/solvers/solver_O3O4.py
@@ -14,6 +14,7 @@ from symfc.solvers.solver_O2O3O4 import (
     reshape_nNNN3333_nx_to_N3N3N3_n3nx,
     set_disps_N3N3N3,
 )
+from symfc.utils.matrix import block_matrix_sandwich
 from symfc.utils.solver_funcs import get_batch_slice, solve_linear_equation
 
 try:
@@ -288,23 +289,11 @@ def prepare_normal_equation_O3O4(
     if verbose:
         print("Solver:", "Calculate X.T @ X and X.T @ y", flush=True)
 
-    mat33 = compress_eigvecs_fc3.dot(
-        compress_eigvecs_fc3.transpose_dot(mat33), left=True
-    )
-    mat34 = compress_eigvecs_fc4.dot(
-        compress_eigvecs_fc3.transpose_dot(mat34), left=True
-    )
-    mat44 = compress_eigvecs_fc4.dot(
-        compress_eigvecs_fc4.transpose_dot(mat44), left=True
-    )
+    mat33 = block_matrix_sandwich(compress_eigvecs_fc3, compress_eigvecs_fc3, mat33)
+    mat34 = block_matrix_sandwich(compress_eigvecs_fc3, compress_eigvecs_fc4, mat34)
+    mat44 = block_matrix_sandwich(compress_eigvecs_fc4, compress_eigvecs_fc4, mat44)
     mat3y = compress_eigvecs_fc3.transpose_dot(mat3y)
     mat4y = compress_eigvecs_fc4.transpose_dot(mat4y)
-
-    # mat33 = compress_eigvecs_fc3.T @ mat33 @ compress_eigvecs_fc3
-    # mat34 = compress_eigvecs_fc3.T @ mat34 @ compress_eigvecs_fc4
-    # mat44 = compress_eigvecs_fc4.T @ mat44 @ compress_eigvecs_fc4
-    # mat3y = compress_eigvecs_fc3.T @ mat3y
-    # mat4y = compress_eigvecs_fc4.T @ mat4y
 
     XTX = np.block([[mat33, mat34], [mat34.T, mat44]])
     XTy = np.hstack([mat3y, mat4y])

--- a/src/symfc/solvers/solver_O4.py
+++ b/src/symfc/solvers/solver_O4.py
@@ -12,6 +12,7 @@ from symfc.solvers.solver_O2O3O4 import (
     reshape_nNNN3333_nx_to_N3N3N3_n3nx,
     set_disps_N3N3N3,
 )
+from symfc.utils.matrix import block_matrix_sandwich
 from symfc.utils.solver_funcs import get_batch_slice, solve_linear_equation
 
 try:
@@ -216,10 +217,8 @@ def prepare_normal_equation_O4(
     if verbose:
         print("Solver:", "Calculate X.T @ X and X.T @ y", flush=True)
 
-    XTX = compress_eigvecs_fc4.dot(compress_eigvecs_fc4.transpose_dot(mat44), left=True)
+    XTX = block_matrix_sandwich(compress_eigvecs_fc4, compress_eigvecs_fc4, mat44)
     XTy = compress_eigvecs_fc4.transpose_dot(mat4y)
-    # XTX = compress_eigvecs_fc4.T @ mat44 @ compress_eigvecs_fc4
-    # XTy = compress_eigvecs_fc4.T @ mat4y
 
     compact_compress_mat_fc4 /= const_fc4
     t_all2 = time.time()

--- a/src/symfc/utils/eig_tools.py
+++ b/src/symfc/utils/eig_tools.py
@@ -457,9 +457,10 @@ def eigsh_projector_use_submatrix(
                 print(eigvecs.shape[1], "eigenvectors are found.", flush=True)
             eigvecs_blocks = append_block(
                 eigvecs_blocks,
-                cmplt.dot(eigvecs),
+                eigvecs,
                 rows=np.arange(p_size),
                 col_begin=col_id,
+                compress=cmplt,
             )
             col_id += eigvecs.shape[1]
 

--- a/src/symfc/utils/matrix.py
+++ b/src/symfc/utils/matrix.py
@@ -1,7 +1,7 @@
 """Utility functions for matrices."""
 
 from dataclasses import dataclass
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 import numpy as np
 from scipy.sparse import csr_array
@@ -32,12 +32,20 @@ class BlockMatrixComponent:
     rows: np.ndarray
     col_begin: int
     col_end: int
+    compress: Optional[Any] = None
 
     def change_indices(self, rows: np.ndarray, col_shift: int):
         """Change indices."""
         self.rows = rows[self.rows]
         self.col_begin += col_shift
         self.col_end += col_shift
+
+    def recover(self):
+        """Recover block from compression."""
+        if self.compress is not None:
+            return self.compress.dot(self.data)
+        else:
+            return self.data
 
 
 @dataclass
@@ -70,7 +78,10 @@ class BlockMatrix:
             raise RuntimeError("Dimension of input numpy array must be one or two.")
 
         for b in self.blocks:
-            dot_matrix[b.rows] += b.data @ mat[b.col_begin : b.col_end]
+            prod = b.data @ mat[b.col_begin : b.col_end]
+            if b.compress is not None:
+                prod = b.compress.dot_from_right(prod)
+            dot_matrix[b.rows] += prod
         return dot_matrix
 
     def dot_from_left(self, mat: np.ndarray):
@@ -78,11 +89,19 @@ class BlockMatrix:
         if len(mat.shape) == 1:
             dot_matrix = np.zeros(self.shape[1])
             for b in self.blocks:
-                dot_matrix[b.col_begin : b.col_end] += mat[b.rows] @ b.data
+                if b.compress is not None:
+                    prod = b.compress.dot_from_left(mat[b.rows]) @ b.data
+                else:
+                    prod = mat[b.rows] @ b.data
+                dot_matrix[b.col_begin : b.col_end] += prod
         elif len(mat.shape) == 2:
             dot_matrix = np.zeros((mat.shape[0], self.shape[1]))
             for b in self.blocks:
-                dot_matrix[:, b.col_begin : b.col_end] += mat[:, b.rows] @ b.data
+                if b.compress is not None:
+                    prod = b.compress.dot_from_left(mat[:, b.rows]) @ b.data
+                else:
+                    prod = mat[:, b.rows] @ b.data
+                dot_matrix[:, b.col_begin : b.col_end] += prod
         else:
             raise RuntimeError("Dimension of input numpy array must be one or two.")
 
@@ -98,7 +117,11 @@ class BlockMatrix:
             raise RuntimeError("Dimension of input numpy array must be one or two.")
 
         for b in self.blocks:
-            dot_matrix[b.col_begin : b.col_end] += b.data.T @ mat[b.rows]
+            if b.compress is not None:
+                prod = b.data.T @ b.compress.transpose_dot_from_right(mat[b.rows])
+            else:
+                prod = b.data.T @ mat[b.rows]
+            dot_matrix[b.col_begin : b.col_end] += prod
         return dot_matrix
 
     def transpose_dot_from_left(self, mat: np.ndarray):
@@ -106,11 +129,17 @@ class BlockMatrix:
         if len(mat.shape) == 1:
             dot_matrix = np.zeros(self.shape[0])
             for b in self.blocks:
-                dot_matrix[b.rows] += mat[b.col_begin : b.col_end] @ b.data.T
+                prod = mat[b.col_begin : b.col_end] @ b.data.T
+                if b.compress is not None:
+                    prod = b.compress.transpose_dot_from_left(prod)
+                dot_matrix[b.rows] += prod
         elif len(mat.shape) == 2:
             dot_matrix = np.zeros((mat.shape[0], self.shape[0]))
             for b in self.blocks:
-                dot_matrix[:, b.rows] += mat[:, b.col_begin : b.col_end] @ b.data.T
+                prod = mat[:, b.col_begin : b.col_end] @ b.data.T
+                if b.compress is not None:
+                    prod = b.compress.transpose_dot_from_left(prod)
+                dot_matrix[:, b.rows] += prod
         else:
             raise RuntimeError("Dimension of input numpy array must be one or two.")
 
@@ -118,6 +147,10 @@ class BlockMatrix:
 
     def compress_matrix(self, mat: np.ndarray):
         """Calculate block_mat.T @ mat @ block_mat."""
+        # TODO: add compress attr
+        for b1 in self.blocks:
+            if b1.compress is not None:
+                raise RuntimeError("Compression matrix does not work.")
         res = np.zeros((self.shape[1], self.shape[1]))
         for b1 in self.blocks:
             for b2 in self.blocks:
@@ -127,6 +160,11 @@ class BlockMatrix:
 
     def compress_csr_matrix(self, mat: csr_array, use_mkl: bool = False):
         """Calculate block_mat.T @ mat(csr) @ block_mat for csr_array."""
+        # TODO: add compress attr
+        for b1 in self.blocks:
+            if b1.compress is not None:
+                raise RuntimeError("Compression matrix does not work.")
+
         if mat.shape[0] < 10000:
             use_mkl = False
         res = np.zeros((self.shape[1], self.shape[1]))
@@ -143,7 +181,11 @@ class BlockMatrix:
         if self.data_full is None:
             self.data_full = np.zeros(self.shape, dtype="double")  # type: ignore
             for b in self.blocks:
-                self.data_full[b.rows, b.col_begin : b.col_end] = b.data
+                if b.compress is not None:
+                    mat = b.compress.dot_from_right(b.data)
+                else:
+                    mat = b.data
+                self.data_full[b.rows, b.col_begin : b.col_end] = mat
         return self.data_full
 
 
@@ -152,6 +194,7 @@ def append_block(
     eigvecs: np.ndarray,
     rows: Optional[np.ndarray] = None,
     col_begin: Optional[int] = None,
+    compress: Optional[BlockMatrix] = None,
 ):
     """Add eigenvectors to block matrix list."""
     if eigvecs is not None and eigvecs.shape[1] > 0:
@@ -161,6 +204,23 @@ def append_block(
             rows=rows,
             col_begin=col_begin,
             col_end=col_end,
+            compress=compress,
         )
         blocks_list.append(block)
     return blocks_list
+
+
+def block_matrix_sandwich(
+    block_matrix1: BlockMatrix,
+    block_matrix2: BlockMatrix,
+    mat: np.ndarray,
+):
+    """Calculate block1.T @ mat @ block2."""
+    res = np.zeros((block_matrix1.shape[1], block_matrix2.shape[1]))
+    for b1 in block_matrix1.blocks:
+        b1_full = b1.recover()
+        for b2 in block_matrix2.blocks:
+            b2_full = b2.recover()
+            prod = b1_full.T @ mat[np.ix_(b1.rows, b2.rows)] @ b2_full
+            res[b1.col_begin : b1.col_end, b2.col_begin : b2.col_end] += prod
+    return res

--- a/src/symfc/utils/matrix.py
+++ b/src/symfc/utils/matrix.py
@@ -44,8 +44,7 @@ class BlockMatrixComponent:
         """Recover block from compression."""
         if self.compress is not None:
             return self.compress.dot(self.data)
-        else:
-            return self.data
+        return self.data
 
 
 @dataclass

--- a/tests/utils/test_block.py
+++ b/tests/utils/test_block.py
@@ -56,3 +56,126 @@ def test_block_matrix():
         bm.compress_csr_matrix(csr_array(mat3)),
         mat.T @ mat3 @ mat,
     )
+
+
+def test_compressed_block_matrix1():
+    """Test compressed matrix in BlockMatrix."""
+    A = mat = np.array([[2, 1], [4, 3], [3, 1], [5, 7]])
+    comprA = np.array(
+        [
+            [4, 3, 2, 1],
+            [6, 9, 8, 4],
+            [2, 1, 6, 8],
+            [9, 2, 3, 7],
+            [7, 3, 0, 9],
+            [0, 8, 1, 3],
+        ]
+    )
+    compr1 = BlockMatrixComponent(
+        data=comprA,
+        rows=np.arange(6),
+        col_begin=0,
+        col_end=4,
+    )
+    compr = BlockMatrix(blocks=[compr1], shape=(6, 4))
+    full_mat = compr.dot(mat)
+
+    block_A = BlockMatrixComponent(
+        data=A,
+        rows=np.arange(6),
+        col_begin=0,
+        col_end=2,
+        compress=compr,
+    )
+    blocks = [block_A]
+    bm = BlockMatrix(blocks=blocks, shape=(6, 2))
+
+    mat2 = np.array([[2, 8], [5, 9]])
+    np.testing.assert_array_equal(bm.dot(mat2), full_mat @ mat2)
+    np.testing.assert_array_equal(
+        bm.transpose_dot(mat2.T, left=True), mat2.T @ full_mat.T
+    )
+
+    vec2 = np.array([3, 1])
+    np.testing.assert_array_equal(bm.dot(vec2), full_mat @ vec2)
+    np.testing.assert_array_equal(bm.transpose_dot(vec2, left=True), vec2 @ full_mat.T)
+
+
+def test_compressed_block_matrix2():
+    """Test complex compressed matrix in BlockMatrix."""
+    A = np.array([[2, 1], [4, 3], [3, 1], [5, 7]])
+    comprA = np.array(
+        [
+            [4, 3, 2, 1],
+            [6, 9, 8, 4],
+            [2, 1, 6, 8],
+            [9, 2, 3, 7],
+            [7, 3, 0, 9],
+            [0, 8, 1, 3],
+        ]
+    )
+    compr1 = BlockMatrixComponent(
+        data=comprA,
+        rows=np.arange(6),
+        col_begin=0,
+        col_end=4,
+    )
+    full_matA = comprA @ A
+    comprA = BlockMatrix(blocks=[compr1], shape=(6, 4))
+
+    B = np.array([[2, 1], [4, 3]])
+    comprB = np.array(
+        [
+            [4, 3],
+            [6, 9],
+            [2, 1],
+            [9, 2],
+            [7, 3],
+            [0, 8],
+        ]
+    )
+    compr2 = BlockMatrixComponent(
+        data=comprB,
+        rows=np.arange(6),
+        col_begin=0,
+        col_end=2,
+    )
+    full_matB = comprB @ B
+    comprB = BlockMatrix(blocks=[compr2], shape=(6, 2))
+
+    full_mat = np.block([full_matA, full_matB])
+
+    block_A = BlockMatrixComponent(
+        data=A,
+        rows=np.arange(6),
+        col_begin=0,
+        col_end=2,
+        compress=comprA,
+    )
+    block_B = BlockMatrixComponent(
+        data=B,
+        rows=np.arange(6),
+        col_begin=2,
+        col_end=4,
+        compress=comprB,
+    )
+    blocks = [block_A, block_B]
+    bm = BlockMatrix(blocks=blocks, shape=(6, 4))
+
+    mat2 = np.array([[2, 8], [5, 9], [3, 2], [7, 5]])
+    np.testing.assert_array_equal(bm.dot(mat2), full_mat @ mat2)
+    np.testing.assert_array_equal(
+        bm.transpose_dot(mat2.T, left=True),
+        mat2.T @ full_mat.T,
+    )
+    mat2 = np.array([[2, 8], [5, 9], [3, 2], [7, 5], [8, 4], [6, 3]])
+    np.testing.assert_array_equal(bm.transpose_dot(mat2), full_mat.T @ mat2)
+    np.testing.assert_array_equal(bm.dot(mat2.T, left=True), mat2.T @ full_mat)
+
+    vec2 = np.array([3, 1, 4, 3])
+    np.testing.assert_array_equal(bm.dot(vec2), full_mat @ vec2)
+    np.testing.assert_array_equal(bm.transpose_dot(vec2, left=True), vec2 @ full_mat.T)
+
+    vec2 = np.array([3, 1, 4, 3, 2, 3])
+    np.testing.assert_array_equal(bm.transpose_dot(vec2), full_mat.T @ vec2)
+    np.testing.assert_array_equal(bm.dot(vec2, left=True), vec2 @ full_mat)


### PR DESCRIPTION
To reduce required memory, both compressed eigenvectors and its compression matrix are kept in `BlockMatrix` without computing cmplt.dot(eigvecs).

- Dot operations in `BlockMatrix` have been revised to be compatible with this compression.
- Tests have been added for checking dot operations of block matrices with compression matrices.