### PR TITLE
Block matrix tree has been implemented.

### DIFF
--- a/src/symfc/basis_sets/basis_sets_O2.py
+++ b/src/symfc/basis_sets/basis_sets_O2.py
@@ -12,7 +12,7 @@ from symfc.utils.eig_tools import (
     eigsh_projector,
     eigsh_projector_sumrule,
 )
-from symfc.utils.matrix import BlockMatrix
+from symfc.utils.matrix import BlockMatrixNode
 
 try:
     from symfc.utils.matrix import dot_product_sparse
@@ -90,7 +90,7 @@ class FCBasisSetO2(FCBasisSetBase):
 
         self._n_a_compression_matrix: Optional[csr_array] = None
         self._basis_set: Optional[np.ndarray] = None
-        self._blocked_basis_set: Optional[BlockMatrix] = None
+        self._blocked_basis_set: Optional[BlockMatrixNode] = None
 
     @property
     def compression_matrix(self) -> Optional[csr_array]:

--- a/src/symfc/basis_sets/basis_sets_O3.py
+++ b/src/symfc/basis_sets/basis_sets_O3.py
@@ -13,7 +13,7 @@ from symfc.utils.eig_tools import (
     eigsh_projector,
     eigsh_projector_sumrule,
 )
-from symfc.utils.matrix import BlockMatrix
+from symfc.utils.matrix import BlockMatrixNode
 
 try:
     from symfc.utils.matrix import dot_product_sparse
@@ -95,7 +95,7 @@ class FCBasisSetO3(FCBasisSetBase):
 
         self._n_a_compression_matrix: Optional[csr_array] = None
         self._basis_set: Optional[np.ndarray] = None
-        self._blocked_basis_set: Optional[BlockMatrix] = None
+        self._blocked_basis_set: Optional[BlockMatrixNode] = None
 
     @property
     def compression_matrix(self) -> Optional[csr_array]:

--- a/src/symfc/basis_sets/basis_sets_O4.py
+++ b/src/symfc/basis_sets/basis_sets_O4.py
@@ -13,7 +13,7 @@ from symfc.utils.eig_tools import (
     eigsh_projector,
     eigsh_projector_sumrule,
 )
-from symfc.utils.matrix import BlockMatrix
+from symfc.utils.matrix import BlockMatrixNode
 
 try:
     from symfc.utils.matrix import dot_product_sparse
@@ -89,7 +89,7 @@ class FCBasisSetO4(FCBasisSetBase):
 
         self._n_a_compression_matrix: Optional[csr_array] = None
         self._basis_set: Optional[np.ndarray] = None
-        self._blocked_basis_set: Optional[BlockMatrix] = None
+        self._blocked_basis_set: Optional[BlockMatrixNode] = None
 
     @property
     def compression_matrix(self) -> Optional[csr_array]:

--- a/src/symfc/basis_sets/basis_sets_base.py
+++ b/src/symfc/basis_sets/basis_sets_base.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from symfc.spg_reps import SpgRepsBase
 from symfc.utils.cutoff_tools import FCCutoff
-from symfc.utils.matrix import BlockMatrix
+from symfc.utils.matrix import BlockMatrixNode
 from symfc.utils.utils import SymfcAtoms
 
 
@@ -44,7 +44,7 @@ class FCBasisSetBase(ABC):
         self._spg_reps: SpgRepsBase
         self._atomic_decompr_idx: np.ndarray
         self._basis_set: np.ndarray
-        self._blocked_basis_set: BlockMatrix
+        self._blocked_basis_set: BlockMatrixNode
 
         if cutoff is None:
             self._fc_cutoff = None
@@ -70,10 +70,10 @@ class FCBasisSetBase(ABC):
         shape=(n_c, n_bases), dtype='double'.
 
         """
-        return self._blocked_basis_set.recover_full_matrix()
+        return self._blocked_basis_set.recover()
 
     @property
-    def blocked_basis_set(self) -> Optional[BlockMatrix]:
+    def blocked_basis_set(self) -> Optional[BlockMatrixNode]:
         """Return compressed basis set in blocked format."""
         return self._blocked_basis_set
 

--- a/src/symfc/solvers/solver_O2O3.py
+++ b/src/symfc/solvers/solver_O2O3.py
@@ -11,7 +11,7 @@ from scipy.sparse import csr_array
 
 from symfc.basis_sets import FCBasisSetO2, FCBasisSetO3
 from symfc.solvers.solver_O2 import reshape_nN33_nx_to_N3_n3nx
-from symfc.utils.matrix import BlockMatrix, block_matrix_sandwich
+from symfc.utils.matrix import BlockMatrixNode, block_matrix_sandwich
 from symfc.utils.solver_funcs import get_batch_slice, solve_linear_equation
 
 try:
@@ -231,8 +231,8 @@ def prepare_normal_equation_O2O3(
     forces: np.ndarray,
     compact_compress_mat_fc2: csr_array,
     compact_compress_mat_fc3: csr_array,
-    compress_eigvecs_fc2: BlockMatrix,
-    compress_eigvecs_fc3: BlockMatrix,
+    compress_eigvecs_fc2: BlockMatrixNode,
+    compress_eigvecs_fc3: BlockMatrixNode,
     atomic_decompr_idx_fc2: np.ndarray,
     atomic_decompr_idx_fc3: np.ndarray,
     batch_size: int = 100,
@@ -372,8 +372,8 @@ def run_solver_O2O3(
     forces: np.ndarray,
     compact_compress_mat_fc2: csr_array,
     compact_compress_mat_fc3: csr_array,
-    compress_eigvecs_fc2: BlockMatrix,
-    compress_eigvecs_fc3: BlockMatrix,
+    compress_eigvecs_fc2: BlockMatrixNode,
+    compress_eigvecs_fc3: BlockMatrixNode,
     atomic_decompr_idx_fc2: np.ndarray,
     atomic_decompr_idx_fc3: np.ndarray,
     batch_size: int = 100,

--- a/src/symfc/utils/eig_tools.py
+++ b/src/symfc/utils/eig_tools.py
@@ -368,10 +368,15 @@ def _find_complement_eigenvectors(
     if verbose:
         print(header, "Complementary block size:", cmplt.shape[1], flush=True)
         print(header, "Submatrix size for complement:", size_cmplt, flush=True)
+        print(header, "Compute compressed projector.", flush=True)
 
+    p_cmr = cmplt.compress_matrix(p, use_mkl=use_mkl)
+
+    if verbose:
+        print(header, "Find eigenvectors.", flush=True)
     if not repeat or cmplt.shape[1] < size_threshold:
         result = eigh_projector(
-            cmplt.compress_matrix(p, use_mkl=use_mkl),
+            p_cmr,
             atol=atol,
             rtol=rtol,
             return_cmplt=return_cmplt,
@@ -379,7 +384,7 @@ def _find_complement_eigenvectors(
         )
     else:
         result = eigh_projector_division(
-            cmplt.compress_matrix(p, use_mkl=use_mkl),
+            p_cmr,
             atol=atol,
             rtol=rtol,
             depth=depth,

--- a/src/symfc/utils/eig_tools.py
+++ b/src/symfc/utils/eig_tools.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 from typing import Optional, Union
 
 import numpy as np
-import scipy
 from scipy.sparse import csr_array
 
 from symfc.utils.matrix import BlockMatrix, append_block
@@ -71,9 +70,10 @@ def _compr_projector(p: csr_array) -> tuple[csr_array, Optional[csr_array]]:
 
 def _find_projector_blocks(p: csr_array):
     """Find block structures in projection matrix."""
-    # from symfc.utils.graph import connected_components
-    # n_components, labels = connected_components(p, verbose=True)
-    n_components, labels = scipy.sparse.csgraph.connected_components(p)
+    from symfc.utils.graph import connected_components
+
+    n_components, labels = connected_components(p, verbose=True)
+    # n_components, labels = scipy.sparse.csgraph.connected_components(p)
     group = defaultdict(list)
     for i, ll in enumerate(labels):
         group[ll].append(i)
@@ -335,9 +335,10 @@ def eigh_projector_use_submatrix(
                 print("  eigenvectors:", eigvecs.shape[1], flush=True)
             eigvecs_blocks = append_block(
                 eigvecs_blocks,
-                cmplt.dot(eigvecs),
+                eigvecs,
                 rows=np.arange(p_size),
                 col_begin=col_id,
+                compress=cmplt,
             )
             col_id += eigvecs.shape[1]
 

--- a/src/symfc/utils/eig_tools.py
+++ b/src/symfc/utils/eig_tools.py
@@ -271,7 +271,7 @@ def _find_submatrix_eigenvectors(
 ):
     """Find eigenvectors in division part of submatrix division algorithm."""
     p_size = p.shape[0]
-    if p_size < 500:
+    if p_size < 200:
         repeat = False
     else:
         repeat = False if depth == 3 else True
@@ -282,7 +282,7 @@ def _find_submatrix_eigenvectors(
         elif depth == 2:
             target_size = min(p_size // 5, 10000)
         elif depth == 3:
-            target_size = min(p_size // 2, 20000)
+            target_size = min(p_size // 3, 20000)
 
     sibling, sibling_c = None, None
     col_id, col_id_c = 0, 0
@@ -367,14 +367,12 @@ def _find_complement_eigenvectors(
     header = "  " * (depth - 1) + "(Depth " + str(depth) + ")"
     if verbose:
         print(header, "Complementary block size:", cmplt.shape[1], flush=True)
-        print(header, "Submatrix size for complement:", size_cmplt, flush=True)
         print(header, "Compute compressed projector.", flush=True)
 
     p_cmr = cmplt.compress_matrix(p, use_mkl=use_mkl)
-
-    if verbose:
-        print(header, "Find eigenvectors.", flush=True)
     if not repeat or cmplt.shape[1] < size_threshold:
+        if verbose:
+            print(header, "Use standard solver.", flush=True)
         result = eigh_projector(
             p_cmr,
             atol=atol,
@@ -383,6 +381,8 @@ def _find_complement_eigenvectors(
             verbose=verbose,
         )
     else:
+        if verbose:
+            print(header, "Use submatrix size of", size_cmplt, flush=True)
         result = eigh_projector_division(
             p_cmr,
             atol=atol,
@@ -430,7 +430,7 @@ def eigh_projector_division(
 ):
     """Solve eigenvalue problem for numpy array."""
     p_size = p.shape[0]
-    if p_size < 500:
+    if p_size < 200:
         return eigh_projector(
             p,
             atol=atol,

--- a/src/symfc/utils/matrix.py
+++ b/src/symfc/utils/matrix.py
@@ -258,7 +258,6 @@ class BlockMatrixNode:
                 col_end2 = b2.col_end_root
                 data2 = b2.decompress()
                 prod = data1.T @ dot_product_sparse(
-                    # mat[np.ix_(b1.rows_root, b2.rows_root)],
                     mat1[:, b2.rows_root],
                     data2,
                     use_mkl=use_mkl,

--- a/src/symfc/utils/matrix.py
+++ b/src/symfc/utils/matrix.py
@@ -34,6 +34,17 @@ class BlockMatrixComponent:
     col_end: int
     compress: Optional[Any] = None
 
+    def __post_init__(self):
+        """Post init method."""
+        if self.data.shape[1] != (self.col_end - self.col_begin):
+            raise RuntimeError("Data shape and col size are inconsistent")
+        if self.compress is None:
+            if self.data.shape[0] != len(self.rows):
+                raise RuntimeError("Data shape and row size are inconsistent")
+        else:
+            if self.compress.shape[0] != len(self.rows):
+                raise RuntimeError("Compression shape and row size are inconsistent")
+
     def change_indices(self, rows: np.ndarray, col_shift: int):
         """Change indices."""
         self.rows = rows[self.rows]
@@ -180,11 +191,7 @@ class BlockMatrix:
         if self.data_full is None:
             self.data_full = np.zeros(self.shape, dtype="double")  # type: ignore
             for b in self.blocks:
-                if b.compress is not None:
-                    mat = b.compress.dot_from_right(b.data)
-                else:
-                    mat = b.data
-                self.data_full[b.rows, b.col_begin : b.col_end] = mat
+                self.data_full[b.rows, b.col_begin : b.col_end] = b.recover()
         return self.data_full
 
 

--- a/src/symfc/utils/matrix.py
+++ b/src/symfc/utils/matrix.py
@@ -1,7 +1,7 @@
 """Utility functions for matrices."""
 
 from dataclasses import dataclass
-from typing import Any, Optional, Self, Union
+from typing import Any, Optional, Union
 
 import numpy as np
 from scipy.sparse import csr_array
@@ -59,9 +59,9 @@ class BlockMatrixNode:
     shape: Optional[tuple] = None
 
     data: Optional[np.ndarray] = None
-    first_child: Optional[Self] = None
-    next_sibling: Optional[Self] = None
-    compress: Optional[Self] = None
+    first_child: Optional[Any] = None
+    next_sibling: Optional[Any] = None
+    compress: Optional[Any] = None
 
     rows_root: Optional[np.ndarray] = None
     col_begin_root: Optional[int] = None

--- a/src/symfc/utils/matrix.py
+++ b/src/symfc/utils/matrix.py
@@ -145,8 +145,7 @@ class BlockMatrixNode:
 
     def compress_matrix(self, mat: np.ndarray):
         """Calculate block_mat.T @ mat @ block_mat for csr_array."""
-        if self.root:
-            res = np.zeros((self.shape[1], self.shape[1]))
+        res = np.zeros((self.shape[1], self.shape[1]))
 
         self.set_full_indices()
         for b1 in self.traverse():
@@ -172,8 +171,8 @@ class BlockMatrixNode:
         """Calculate block_mat.T @ mat(csr) @ block_mat for csr_array."""
         if mat.shape[0] < 10000:
             use_mkl = False
-        if self.root:
-            res = np.zeros((self.shape[1], self.shape[1]))
+
+        res = np.zeros((self.shape[1], self.shape[1]))
 
         self.set_full_indices()
         for b1 in self.traverse():
@@ -201,6 +200,28 @@ class BlockMatrixNode:
                 )
                 res[col_begin1:col_end1, col_begin2:col_end2] += prod
         return res
+
+
+def append_node(
+    eigvecs: np.ndarray,
+    next_sibling: BlockMatrixNode,
+    rows: Optional[np.ndarray] = None,
+    col_begin: Optional[int] = None,
+    compress: Optional[BlockMatrixNode] = None,
+):
+    """Add eigenvectors to block matrix node."""
+    if eigvecs is not None and eigvecs.shape[1] > 0:
+        col_end = col_begin + eigvecs.shape[1]  # type: ignore
+        block = BlockMatrixNode(
+            rows=rows,
+            col_begin=col_begin,
+            col_end=col_end,
+            data=eigvecs,
+            next_sibling=next_sibling,
+            compress=compress,
+        )
+        next_sibling = block
+    return next_sibling
 
 
 # def block_matrix_sandwich(

--- a/tests/test_api_linalg.py
+++ b/tests/test_api_linalg.py
@@ -36,7 +36,7 @@ def test_eigsh_and_eigh():
     _assert_four_atoms_eigvecs(eigvecs)
 
     eigvecs = eigsh(proj, is_large_block=True, log_level=0)
-    eigvecs = eigvecs.recover_full_matrix()
+    eigvecs = eigvecs.recover()
     _assert_four_atoms_eigvecs(eigvecs)
 
     eigvecs = eigh(proj.toarray(), log_level=0)

--- a/tests/utils/test_block_tree.py
+++ b/tests/utils/test_block_tree.py
@@ -1,6 +1,7 @@
 """Tests of block matrix functions."""
 
 import numpy as np
+from scipy.sparse import csr_array
 
 from symfc.utils.matrix import BlockMatrixNode
 
@@ -25,6 +26,7 @@ def test_block_matrix():
         col_begin=0,
         col_end=2,
         data=mat[0:2, 0:2],
+        index=0,
     )
     block1_2 = BlockMatrixNode(
         rows=[0, 1],
@@ -32,6 +34,7 @@ def test_block_matrix():
         col_end=4,
         data=mat[0:2, 2:4],
         next_sibling=block1_1,
+        index=1,
     )
     block1_3 = BlockMatrixNode(
         rows=[2, 3],
@@ -39,12 +42,14 @@ def test_block_matrix():
         col_end=4,
         data=mat[2:4, 2:4],
         next_sibling=block1_2,
+        index=2,
     )
     block1 = BlockMatrixNode(
         rows=[0, 1, 2, 3],
         col_begin=0,
         col_end=4,
         first_child=block1_3,
+        index=3,
     )
 
     block2_1 = BlockMatrixNode(
@@ -52,6 +57,7 @@ def test_block_matrix():
         col_begin=0,
         col_end=2,
         data=mat[0:2, 4:6],
+        index=4,
     )
     block2_2 = BlockMatrixNode(
         rows=[2, 3],
@@ -59,6 +65,7 @@ def test_block_matrix():
         col_end=2,
         data=mat[2:4, 4:6],
         next_sibling=block2_1,
+        index=5,
     )
     block2_3 = BlockMatrixNode(
         rows=[2, 3],
@@ -66,6 +73,7 @@ def test_block_matrix():
         col_end=4,
         data=mat[2:4, 6:8],
         next_sibling=block2_2,
+        index=6,
     )
     block2 = BlockMatrixNode(
         rows=[0, 1, 2, 3],
@@ -73,6 +81,7 @@ def test_block_matrix():
         col_end=8,
         first_child=block2_3,
         next_sibling=block1,
+        index=7,
     )
 
     block3_1 = BlockMatrixNode(
@@ -80,6 +89,7 @@ def test_block_matrix():
         col_begin=0,
         col_end=2,
         data=mat[4:6, 4:6],
+        index=8,
     )
     block3_2 = BlockMatrixNode(
         rows=[0, 1],
@@ -87,6 +97,7 @@ def test_block_matrix():
         col_end=4,
         data=mat[4:6, 6:8],
         next_sibling=block3_1,
+        index=9,
     )
     block3_3 = BlockMatrixNode(
         rows=[2, 3],
@@ -94,6 +105,7 @@ def test_block_matrix():
         col_end=2,
         data=mat[6:8, 4:6],
         next_sibling=block3_2,
+        index=10,
     )
     block3 = BlockMatrixNode(
         rows=[4, 5, 6, 7],
@@ -101,6 +113,7 @@ def test_block_matrix():
         col_end=8,
         first_child=block3_3,
         next_sibling=block2,
+        index=11,
     )
 
     cblock1 = BlockMatrixNode(
@@ -108,6 +121,7 @@ def test_block_matrix():
         col_begin=0,
         col_end=1,
         data=np.array([[4], [5]]),
+        index=101,
     )
     cblock2 = BlockMatrixNode(
         rows=[2, 3],
@@ -115,6 +129,7 @@ def test_block_matrix():
         col_end=1,
         data=np.array([[1], [3]]),
         next_sibling=cblock1,
+        index=102,
     )
     cblock3 = BlockMatrixNode(
         rows=[2, 3],
@@ -122,6 +137,7 @@ def test_block_matrix():
         col_end=2,
         data=np.array([[2], [4]]),
         next_sibling=cblock2,
+        index=103,
     )
     cmplt = BlockMatrixNode(
         rows=[0, 1, 2, 3],
@@ -129,6 +145,7 @@ def test_block_matrix():
         col_end=2,
         first_child=cblock3,
         root=True,
+        index=104,
     )
     eigvecs = np.array([[1, 0], [2, 1]])
     mat[4:8, 0:2] = cmplt.dot(eigvecs)
@@ -140,6 +157,7 @@ def test_block_matrix():
         data=eigvecs,
         next_sibling=block3,
         compress=cmplt,
+        index=12,
     )
 
     bm = BlockMatrixNode(
@@ -148,13 +166,37 @@ def test_block_matrix():
         col_end=8,
         first_child=block4,
         root=True,
+        index=13,
     )
 
     mat2 = np.array([[3, 1], [5, 7], [2, 8], [5, 9], [3, 2], [4, 5], [7, 2], [2, 1]])
-    # vec2 = np.array([3, 1, 5, 7])
+    vec2 = np.array([3, 1, 5, 7, 2, 3, 3, 1])
 
     np.testing.assert_array_equal(bm.dot(mat2), mat @ mat2)
+    np.testing.assert_array_equal(bm.dot(vec2), mat @ vec2)
     np.testing.assert_array_equal(bm.recover_full_matrix(), mat)
+
+    mat3 = np.array(
+        [
+            [3, 1, 4, 3, 0, 0, 2, 0],
+            [5, 7, 3, 1, 2, 1, 0, 6],
+            [2, 8, 7, 4, 3, 9, 9, 0],
+            [5, 9, 0, 2, 0, 0, 0, 2],
+            [2, 3, 4, 9, 1, 0, 1, 2],
+            [0, 2, 0, 2, 0, 8, 0, 3],
+            [5, 9, 0, 2, 0, 0, 2, 2],
+            [0, 0, 0, 2, 2, 0, 9, 1],
+        ]
+    )
+
+    print(mat.T @ mat3 @ mat)
+    np.testing.assert_array_equal(
+        bm.compress_csr_matrix(csr_array(mat3)),
+        mat.T @ mat3 @ mat,
+    )
+
+    # perm = [2, 1, 0, 4, 3, 6, 5, 7]
+    # bm.rows = perm
 
 
 #     np.testing.assert_array_equal(bm.dot(vec2), mat @ vec2)

--- a/tests/utils/test_block_tree.py
+++ b/tests/utils/test_block_tree.py
@@ -197,10 +197,11 @@ def test_block_matrix():
         mat.T @ mat3 @ mat,
     )
 
-    perm = [2, 1, 0, 4, 3, 6, 5, 7]
-    bm.rows = perm
-    mat = mat[perm]
-    np.testing.assert_array_equal(bm.dot(mat2), mat @ mat2)
+
+#    perm = np.array([2, 1, 0, 4, 3, 6, 5, 7])
+#    bm.rows = perm
+#    mat = mat[perm]
+#    np.testing.assert_array_equal(bm.dot(mat2), mat @ mat2)
 
 
 #     np.testing.assert_array_equal(bm.dot(vec2), mat @ vec2)

--- a/tests/utils/test_block_tree.py
+++ b/tests/utils/test_block_tree.py
@@ -1,0 +1,178 @@
+"""Tests of block matrix functions."""
+
+import numpy as np
+
+from symfc.utils.matrix import BlockMatrixNode
+
+
+def test_block_matrix():
+    """Test BlockMatrix."""
+    mat = np.array(
+        [
+            [5, 4, 3, 2, 7, 4, 0, 0],
+            [4, 3, 2, 1, 8, 3, 0, 0],
+            [0, 0, 6, 2, 8, 7, 7, 2],
+            [0, 0, 1, 4, 3, 3, 1, 8],
+            [0, 0, 0, 0, 5, 3, 9, 1],
+            [0, 0, 0, 0, 3, 4, 1, 2],
+            [0, 0, 0, 0, 7, 8, 0, 0],
+            [0, 0, 0, 0, 7, 2, 0, 0],
+        ]
+    )
+
+    block1_1 = BlockMatrixNode(
+        rows=[0, 1],
+        col_begin=0,
+        col_end=2,
+        data=mat[0:2, 0:2],
+    )
+    block1_2 = BlockMatrixNode(
+        rows=[0, 1],
+        col_begin=2,
+        col_end=4,
+        data=mat[0:2, 2:4],
+        next_sibling=block1_1,
+    )
+    block1_3 = BlockMatrixNode(
+        rows=[2, 3],
+        col_begin=2,
+        col_end=4,
+        data=mat[2:4, 2:4],
+        next_sibling=block1_2,
+    )
+    block1 = BlockMatrixNode(
+        rows=[0, 1, 2, 3],
+        col_begin=0,
+        col_end=4,
+        first_child=block1_3,
+    )
+
+    block2_1 = BlockMatrixNode(
+        rows=[0, 1],
+        col_begin=0,
+        col_end=2,
+        data=mat[0:2, 4:6],
+    )
+    block2_2 = BlockMatrixNode(
+        rows=[2, 3],
+        col_begin=0,
+        col_end=2,
+        data=mat[2:4, 4:6],
+        next_sibling=block2_1,
+    )
+    block2_3 = BlockMatrixNode(
+        rows=[2, 3],
+        col_begin=2,
+        col_end=4,
+        data=mat[2:4, 6:8],
+        next_sibling=block2_2,
+    )
+    block2 = BlockMatrixNode(
+        rows=[0, 1, 2, 3],
+        col_begin=4,
+        col_end=8,
+        first_child=block2_3,
+        next_sibling=block1,
+    )
+
+    block3_1 = BlockMatrixNode(
+        rows=[0, 1],
+        col_begin=0,
+        col_end=2,
+        data=mat[4:6, 4:6],
+    )
+    block3_2 = BlockMatrixNode(
+        rows=[0, 1],
+        col_begin=2,
+        col_end=4,
+        data=mat[4:6, 6:8],
+        next_sibling=block3_1,
+    )
+    block3_3 = BlockMatrixNode(
+        rows=[2, 3],
+        col_begin=0,
+        col_end=2,
+        data=mat[6:8, 4:6],
+        next_sibling=block3_2,
+    )
+    block3 = BlockMatrixNode(
+        rows=[4, 5, 6, 7],
+        col_begin=4,
+        col_end=8,
+        first_child=block3_3,
+        next_sibling=block2,
+    )
+
+    cblock1 = BlockMatrixNode(
+        rows=[0, 1],
+        col_begin=0,
+        col_end=1,
+        data=np.array([[4], [5]]),
+    )
+    cblock2 = BlockMatrixNode(
+        rows=[2, 3],
+        col_begin=0,
+        col_end=1,
+        data=np.array([[1], [3]]),
+        next_sibling=cblock1,
+    )
+    cblock3 = BlockMatrixNode(
+        rows=[2, 3],
+        col_begin=1,
+        col_end=2,
+        data=np.array([[2], [4]]),
+        next_sibling=cblock2,
+    )
+    cmplt = BlockMatrixNode(
+        rows=[0, 1, 2, 3],
+        col_begin=0,
+        col_end=2,
+        first_child=cblock3,
+        root=True,
+    )
+    eigvecs = np.array([[1, 0], [2, 1]])
+    mat[4:8, 0:2] = cmplt.dot(eigvecs)
+
+    block4 = BlockMatrixNode(
+        rows=[4, 5, 6, 7],
+        col_begin=0,
+        col_end=2,
+        data=eigvecs,
+        next_sibling=block3,
+        compress=cmplt,
+    )
+
+    root_block = BlockMatrixNode(
+        rows=[0, 1, 2, 3, 4, 5, 6, 7],
+        col_begin=0,
+        col_end=8,
+        first_child=block4,
+        root=True,
+    )
+
+    mat2 = np.array([[3, 1], [5, 7], [2, 8], [5, 9], [3, 2], [4, 5], [7, 2], [2, 1]])
+    # vec2 = np.array([3, 1, 5, 7])
+
+    print(mat @ mat2)
+    np.testing.assert_array_equal(root_block.dot(mat2), mat @ mat2)
+
+
+#     np.testing.assert_array_equal(bm.dot(vec2), mat @ vec2)
+#     np.testing.assert_array_equal(bm.transpose_dot(vec2), mat.T @ vec2)
+#     np.testing.assert_array_equal(bm.dot(vec2, left=True), vec2 @ mat)
+#     np.testing.assert_array_equal(bm.transpose_dot(vec2, left=True), vec2 @ mat.T)
+#
+#     np.testing.assert_array_equal(bm.dot(mat2), mat @ mat2)
+#     np.testing.assert_array_equal(bm.transpose_dot(mat2), mat.T @ mat2)
+#     np.testing.assert_array_equal(bm.dot(mat2.T, left=True), mat2.T @ mat)
+#     np.testing.assert_array_equal(
+#         bm.transpose_dot(mat2.T, left=True),
+#         mat2.T @ mat.T,
+#     )
+#
+#     mat3 = np.array([[3, 1, 4, 3], [5, 7, 3, 1], [2, 8, 7, 4], [5, 9, 0, 2]])
+#     np.testing.assert_array_equal(bm.compress_matrix(mat3), mat.T @ mat3 @ mat)
+#     np.testing.assert_array_equal(
+#         bm.compress_csr_matrix(csr_array(mat3)),
+#         mat.T @ mat3 @ mat,
+#     )

--- a/tests/utils/test_block_tree.py
+++ b/tests/utils/test_block_tree.py
@@ -174,7 +174,7 @@ def test_block_matrix():
 
     np.testing.assert_array_equal(bm.dot(mat2), mat @ mat2)
     np.testing.assert_array_equal(bm.dot(vec2), mat @ vec2)
-    np.testing.assert_array_equal(bm.recover_full_matrix(), mat)
+    np.testing.assert_array_equal(bm.recover(), mat)
 
     mat3 = np.array(
         [
@@ -188,15 +188,19 @@ def test_block_matrix():
             [0, 0, 0, 2, 2, 0, 9, 1],
         ]
     )
-
-    print(mat.T @ mat3 @ mat)
+    np.testing.assert_array_equal(
+        bm.compress_matrix(mat3),
+        mat.T @ mat3 @ mat,
+    )
     np.testing.assert_array_equal(
         bm.compress_csr_matrix(csr_array(mat3)),
         mat.T @ mat3 @ mat,
     )
 
-    # perm = [2, 1, 0, 4, 3, 6, 5, 7]
-    # bm.rows = perm
+    perm = [2, 1, 0, 4, 3, 6, 5, 7]
+    bm.rows = perm
+    mat = mat[perm]
+    np.testing.assert_array_equal(bm.dot(mat2), mat @ mat2)
 
 
 #     np.testing.assert_array_equal(bm.dot(vec2), mat @ vec2)
@@ -207,14 +211,3 @@ def test_block_matrix():
 #     np.testing.assert_array_equal(bm.dot(mat2), mat @ mat2)
 #     np.testing.assert_array_equal(bm.transpose_dot(mat2), mat.T @ mat2)
 #     np.testing.assert_array_equal(bm.dot(mat2.T, left=True), mat2.T @ mat)
-#     np.testing.assert_array_equal(
-#         bm.transpose_dot(mat2.T, left=True),
-#         mat2.T @ mat.T,
-#     )
-#
-#     mat3 = np.array([[3, 1, 4, 3], [5, 7, 3, 1], [2, 8, 7, 4], [5, 9, 0, 2]])
-#     np.testing.assert_array_equal(bm.compress_matrix(mat3), mat.T @ mat3 @ mat)
-#     np.testing.assert_array_equal(
-#         bm.compress_csr_matrix(csr_array(mat3)),
-#         mat.T @ mat3 @ mat,
-#     )

--- a/tests/utils/test_block_tree.py
+++ b/tests/utils/test_block_tree.py
@@ -172,9 +172,13 @@ def test_block_matrix():
     mat2 = np.array([[3, 1], [5, 7], [2, 8], [5, 9], [3, 2], [4, 5], [7, 2], [2, 1]])
     vec2 = np.array([3, 1, 5, 7, 2, 3, 3, 1])
 
+    np.testing.assert_array_equal(bm.recover(), mat)
+
     np.testing.assert_array_equal(bm.dot(mat2), mat @ mat2)
     np.testing.assert_array_equal(bm.dot(vec2), mat @ vec2)
-    np.testing.assert_array_equal(bm.recover(), mat)
+
+    np.testing.assert_array_equal(bm.transpose_dot(mat2), mat.T @ mat2)
+    np.testing.assert_array_equal(bm.transpose_dot(vec2), mat.T @ vec2)
 
     mat3 = np.array(
         [
@@ -193,22 +197,12 @@ def test_block_matrix():
         mat.T @ mat3 @ mat,
     )
     np.testing.assert_array_equal(
-        bm.compress_csr_matrix(csr_array(mat3)),
+        bm.compress_matrix(csr_array(mat3)),
         mat.T @ mat3 @ mat,
     )
 
-
-#    perm = np.array([2, 1, 0, 4, 3, 6, 5, 7])
-#    bm.rows = perm
-#    mat = mat[perm]
-#    np.testing.assert_array_equal(bm.dot(mat2), mat @ mat2)
-
-
-#     np.testing.assert_array_equal(bm.dot(vec2), mat @ vec2)
-#     np.testing.assert_array_equal(bm.transpose_dot(vec2), mat.T @ vec2)
-#     np.testing.assert_array_equal(bm.dot(vec2, left=True), vec2 @ mat)
-#     np.testing.assert_array_equal(bm.transpose_dot(vec2, left=True), vec2 @ mat.T)
-#
-#     np.testing.assert_array_equal(bm.dot(mat2), mat @ mat2)
-#     np.testing.assert_array_equal(bm.transpose_dot(mat2), mat.T @ mat2)
-#     np.testing.assert_array_equal(bm.dot(mat2.T, left=True), mat2.T @ mat)
+    perm = np.array([2, 1, 0, 4, 3, 6, 5, 7])
+    bm.rows = perm
+    bm.set_root_indices()
+    mat = mat[perm]
+    np.testing.assert_array_equal(bm.dot(mat2), mat @ mat2)

--- a/tests/utils/test_block_tree.py
+++ b/tests/utils/test_block_tree.py
@@ -142,7 +142,7 @@ def test_block_matrix():
         compress=cmplt,
     )
 
-    root_block = BlockMatrixNode(
+    bm = BlockMatrixNode(
         rows=[0, 1, 2, 3, 4, 5, 6, 7],
         col_begin=0,
         col_end=8,
@@ -153,8 +153,8 @@ def test_block_matrix():
     mat2 = np.array([[3, 1], [5, 7], [2, 8], [5, 9], [3, 2], [4, 5], [7, 2], [2, 1]])
     # vec2 = np.array([3, 1, 5, 7])
 
-    print(mat @ mat2)
-    np.testing.assert_array_equal(root_block.dot(mat2), mat @ mat2)
+    np.testing.assert_array_equal(bm.dot(mat2), mat @ mat2)
+    np.testing.assert_array_equal(bm.recover_full_matrix(), mat)
 
 
 #     np.testing.assert_array_equal(bm.dot(vec2), mat @ vec2)

--- a/tests/utils/test_eig_tools.py
+++ b/tests/utils/test_eig_tools.py
@@ -38,7 +38,7 @@ def test_eigsh_projector():
         assert np.all(np.isclose(eigvecs[:, i][nonzero], eigvecs[nonzero[0], i]))
 
     eigvecs = eigsh_projector_sumrule(proj, verbose=False)
-    eigvecs = eigvecs.recover_full_matrix()
+    eigvecs = eigvecs.recover()
 
     assert eigvecs.shape[1] == 3
     assert np.linalg.norm(eigvecs[:, 0]) == pytest.approx(1.0)

--- a/tests/utils/test_eig_tools.py
+++ b/tests/utils/test_eig_tools.py
@@ -7,7 +7,7 @@ from scipy.sparse import csr_array
 from symfc.utils.eig_tools import (
     _compr_projector,
     eigh_projector,
-    eigh_projector_use_submatrix,
+    eigh_projector_division,
     eigsh_projector,
     eigsh_projector_sumrule,
 )
@@ -76,7 +76,7 @@ def test_eigh_projector():
         nonzero = np.where(np.abs(eigvecs[:, i]) > 1e-12)[0]
         assert np.all(np.isclose(eigvecs[:, i][nonzero], eigvecs[nonzero[0], i]))
 
-    eigvecs = eigh_projector_use_submatrix(proj, verbose=False)
+    eigvecs = eigh_projector_division(proj, verbose=False)
 
     assert eigvecs.shape[1] == 3
     assert np.linalg.norm(eigvecs[:, 0]) == pytest.approx(1.0)


### PR DESCRIPTION
Block matrix tree has been implemented to reduce memory allocation and simply represent a hierarchical structure of block matrix in symfc.

Given a block matrix tree, dot products can be calculated as follows.
```python
bm = symfc.basis_set[order].blocked_basis_set
prod = bm.dot(mat) # bm @ mat
or
prod = bm.transpose_dot(mat) # bm.T @ mat
```