### PR TITLE
Change recursion limit

### DIFF
--- a/src/symfc/utils/matrix.py
+++ b/src/symfc/utils/matrix.py
@@ -12,6 +12,11 @@ except ImportError:
     pass
 
 
+import sys
+
+sys.setrecursionlimit(100000)
+
+
 def dot_product_sparse(
     A: Union[np.ndarray, csr_array],
     B: Union[np.ndarray, csr_array],


### PR DESCRIPTION
The recursion limit size has been temporarily increased from the default of 1000 to 100,000. 
When the number of sibling branches exceeds 100,000, "RecursionError: maximum recursion depth exceeded" will be raised.