### PR TITLE
Bug fixed in basis construction for large systems

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: symfc test using conda-forge environment
 
 on:
   pull_request:
-    branches: [ develop ]
+    branches: [develop]
 
 jobs:
   build-linux:
@@ -15,27 +15,27 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: conda-incubator/setup-miniconda@v3
-      with:
-        auto-update-conda: true
-        channels: conda-forge
-        channel-priority: strict
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        conda activate test
-        conda install --yes -c conda-forge python=${{ matrix.python-version }}
-        conda install --yes -c conda-forge spglib scipy numpy pytest codecov pytest-cov
-    - name: Setup symfc
-      run: |
-        conda activate test
-        pip install -e . -vvv
-    - name: Test with pytest
-      run: |
-        conda activate test
-        pytest -v --cov=./ --cov-report=xml
-    - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v3
-      with:
-        verbose: true
+      - uses: actions/checkout@v5
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          activate-environment: test
+          auto-activate-base: false
+          miniforge-version: latest
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          conda activate test
+          conda install --yes -c conda-forge python=${{ matrix.python-version }}
+          conda install --yes -c conda-forge spglib scipy numpy pytest codecov pytest-cov
+      - name: Setup symfc
+        run: |
+          conda activate test
+          pip install -e . -vvv
+      - name: Test with pytest
+        run: |
+          conda activate test
+          pytest -v --cov=./ --cov-report=xml
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          verbose: true

--- a/src/symfc/basis_sets/basis_sets_O4.py
+++ b/src/symfc/basis_sets/basis_sets_O4.py
@@ -180,7 +180,7 @@ class FCBasisSetO4(FCBasisSetBase):
             if self._log_level:
                 print("---", flush=True)
                 time_pr = "{:.3f}".format(tt6 - tt1)
-                print("Time (Basis FC3)                   :", time_pr, flush=True)
+                print("Time (Basis FC4)                   :", time_pr, flush=True)
                 print("---", flush=True)
                 shape = self._blocked_basis_set.shape
                 print("Final size of basis set:", shape, flush=True)

--- a/src/symfc/eig_solvers/eig_tools_core.py
+++ b/src/symfc/eig_solvers/eig_tools_core.py
@@ -51,29 +51,33 @@ class EigenvectorResult:
         if self.eigvecs is None:
             return None
 
-        # if isinstance(self.eigvecs, BlockMatrixNode):
-        #     if self.compress is None:
-        #         return self.eigvecs
+        if isinstance(self.eigvecs, BlockMatrixNode):
+            if self.compress is None:
+                return self.eigvecs
 
-        #     eigvecs_dense = self.compress.dot(self.eigvecs.recover())
-        #     return BlockMatrixNode(
-        #         rows=np.arange(self.compress.shape[0]),
-        #         col_begin=0,
-        #         col_end=eigvecs_dense.shape[1],
-        #         data=eigvecs_dense,
-        #     )
+            data = self.eigvecs.recover()
+        else:
+            data = self.eigvecs
+
+            # return BlockMatrixNode(
+            #     rows=np.arange(self.compress.shape[0]),
+            #     col_begin=0,
+            #     col_end=data.shape[1],
+            #     data=data,
+            #     compress=self.compress,
+            # )
 
         if self.compress is not None:
             row_shape = self.compress.shape[0]
         else:
-            row_shape = self.eigvecs.shape[0]
-        col_shape = self.eigvecs.shape[1]
+            row_shape = data.shape[0]
+        col_shape = data.shape[1]
 
         block = BlockMatrixNode(
             rows=np.arange(row_shape),
             col_begin=0,
             col_end=col_shape,
-            data=self.eigvecs,
+            data=data,
             compress=self.compress,
         )
         return block

--- a/src/symfc/eig_solvers/eig_tools_core.py
+++ b/src/symfc/eig_solvers/eig_tools_core.py
@@ -54,18 +54,9 @@ class EigenvectorResult:
         if isinstance(self.eigvecs, BlockMatrixNode):
             if self.compress is None:
                 return self.eigvecs
-
             data = self.eigvecs.recover()
         else:
             data = self.eigvecs
-
-            # return BlockMatrixNode(
-            #     rows=np.arange(self.compress.shape[0]),
-            #     col_begin=0,
-            #     col_end=data.shape[1],
-            #     data=data,
-            #     compress=self.compress,
-            # )
 
         if self.compress is not None:
             row_shape = self.compress.shape[0]

--- a/src/symfc/eig_solvers/eig_tools_core.py
+++ b/src/symfc/eig_solvers/eig_tools_core.py
@@ -50,8 +50,18 @@ class EigenvectorResult:
         """Return eigenvectors in BlockMatrixNode."""
         if self.eigvecs is None:
             return None
-        if isinstance(self.eigvecs, BlockMatrixNode):
-            return self.eigvecs
+
+        # if isinstance(self.eigvecs, BlockMatrixNode):
+        #     if self.compress is None:
+        #         return self.eigvecs
+
+        #     eigvecs_dense = self.compress.dot(self.eigvecs.recover())
+        #     return BlockMatrixNode(
+        #         rows=np.arange(self.compress.shape[0]),
+        #         col_begin=0,
+        #         col_end=eigvecs_dense.shape[1],
+        #         data=eigvecs_dense,
+        #     )
 
         if self.compress is not None:
             row_shape = self.compress.shape[0]

--- a/src/symfc/eig_solvers/eig_tools_recursive.py
+++ b/src/symfc/eig_solvers/eig_tools_recursive.py
@@ -21,6 +21,7 @@ from symfc.utils.solver_funcs import get_batch_slice
 
 # Threshold constants for eigenvalue solvers
 MIN_BLOCK_SIZE = 500
+# MIN_BLOCK_SIZE = 3000
 LARGE_BLOCK_SIZE = 5000
 VERY_LARGE_BLOCK_SIZE = 30000
 MAX_BATCH_SIZE = 20000
@@ -156,6 +157,7 @@ def _find_complement_eigenvectors(
         print(header, "Compute compressed projector.", flush=True)
 
     p_cmr = cmplt.compress_matrix(p, use_mkl=use_mkl)
+
     if not repeat:
         if verbose:
             print(header, "Use standard solver.", flush=True)

--- a/src/symfc/eig_solvers/eig_tools_recursive.py
+++ b/src/symfc/eig_solvers/eig_tools_recursive.py
@@ -21,7 +21,6 @@ from symfc.utils.solver_funcs import get_batch_slice
 
 # Threshold constants for eigenvalue solvers
 MIN_BLOCK_SIZE = 500
-# MIN_BLOCK_SIZE = 3000
 LARGE_BLOCK_SIZE = 5000
 VERY_LARGE_BLOCK_SIZE = 30000
 MAX_BATCH_SIZE = 20000
@@ -157,7 +156,6 @@ def _find_complement_eigenvectors(
         print(header, "Compute compressed projector.", flush=True)
 
     p_cmr = cmplt.compress_matrix(p, use_mkl=use_mkl)
-
     if not repeat:
         if verbose:
             print(header, "Use standard solver.", flush=True)

--- a/src/symfc/solvers/solver_O2O3O4.py
+++ b/src/symfc/solvers/solver_O2O3O4.py
@@ -208,13 +208,13 @@ def _get_linked_compress_eigvecs(
     shape3 = compress_eigvecs_fc3.shape
     shape4 = compress_eigvecs_fc4.shape
 
-    compress_eigvecs_fc3 = link_block_matrix_nodes(
+    _ = link_block_matrix_nodes(
         compress_eigvecs_fc3,
         compress_eigvecs_fc2,
         rows=np.arange(shape2[0], shape2[0] + shape3[0]),
         col_begin=shape2[1],
     )
-    compress_eigvecs_fc4 = link_block_matrix_nodes(
+    _ = link_block_matrix_nodes(
         compress_eigvecs_fc4,
         compress_eigvecs_fc3,
         rows=np.arange(shape2[0] + shape3[0], shape2[0] + shape3[0] + shape4[0]),


### PR DESCRIPTION
Some bugs have been fixed in recursive eigh_solver used for basis construction.
When a block matrix is given as a set of blocked `compress_mat` and blocked eigenvectors, the blocked eigenvectors need to be transformed into a NumPy array.
